### PR TITLE
Issue 52 nice, recent_cpu, load_avg, ready_threads 선언 및 초기화

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -29,8 +29,13 @@ typedef int tid_t;
 #define PRI_MAX 63                      /* Highest priority. */
 
 /* MLFQS에서 사용하는 Fixed Point */
-typedef int64_t fixed_t;				/* 타입 이름 */
-#define FIXED_SCALE 1<<14;				
+typedef int fixed_t;				/* 타입 이름 */
+#define FIXED_SCALE (1<<14)		
+
+//load_avg, ready_threads 선언
+static fixed_t load_avg;
+static int ready_threads;
+
 
 /* A kernel thread or user process.
  *
@@ -100,6 +105,10 @@ struct thread {
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
 	struct list_elem sleep_elem;		/* Sleep List element. */
+	//recent_cpu, nice 선언
+	fixed_t recent_cpu;
+	int nice;
+
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -121,7 +121,8 @@ thread_init (void) {
 	list_init (&ready_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
-
+	//스레드 개수와 load_avg의 값을 0으로 초기화
+	ready_threads = load_avg = 0;
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
@@ -434,6 +435,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
+	//스레드의 기본 nice=0, recent_cpu=0;
+	t->nice = t->recent_cpu = 0;
+	
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should


### PR DESCRIPTION
## 변경 사항

-nice, recent_cpu, load_avg, ready_threads선언
-nice, recent_cpu를 init_thread와 load_avg, ready_threads를  thread_init에서 0으로 초기화

## 테스트 방법

1. 해당 값을 생성했을때 값을 찍어볼 수 있습니다.

## 리뷰어가 확인할 것

- [x] 모든 테스트가 통과하는가??

## 관련 이슈
Closes #52 