### PR TITLE
Issue 54 thread get recent cpu,thread get load avg

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -32,9 +32,6 @@ typedef int tid_t;
 typedef int fixed_t;				/* 타입 이름 */
 #define FIXED_SCALE (1 << 14)
 
-//load_avg, ready_threads 선언
-static fixed_t load_avg;
-static int ready_threads;
 
 /* A kernel thread or user process.
  *

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -37,6 +37,8 @@ static bool priority_isless(const struct list_elem* a ,const struct list_elem* b
 }
 static struct list sleep_list;
 
+
+
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -62,6 +64,9 @@ static unsigned thread_ticks;   /* # of timer ticks since last yield. */
    If true, use multi-level feedback queue scheduler.
    Controlled by kernel command-line option "-o mlfqs". */
 bool thread_mlfqs;
+
+static int ready_threads;			/* ready list에 있는 thread 개수 */
+static fixed_t load_avg;			/* ready list에 있는 thread 개수가 클수록 큰 값을 가짐*/
 
 static void kernel_thread (thread_func *, void *aux);
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -375,15 +375,13 @@ thread_get_nice (void) {
 /* Returns 100 times the system load average. */
 int
 thread_get_load_avg (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+	return fixed_to_int_nearest((load_avg) * 100);
 }
 
 /* Returns 100 times the current thread's recent_cpu value. */
 int
 thread_get_recent_cpu (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+	return fixed_to_int_nearest((thread_current ()->recent_cpu) * 100);
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.
@@ -669,7 +667,6 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
-
 
 fixed_t 
 fixed_convert (int n) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -74,6 +74,8 @@ static tid_t allocate_tid (void);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
 
+
+/* MLFQS에서 사용하는 Fixed Point 연산을 위한 helper functions */
 fixed_t fixed_convert (int);
 fixed_t fixed_multiply (fixed_t,fixed_t);
 fixed_t fixed_divide (fixed_t,fixed_t);


### PR DESCRIPTION
 ## 변경 사항

  - `thread_get_load_avg()`가 `load_avg * 100` 값을 nearest rounding으로 반환하도록 구현했습니다.
  - `thread_get_recent_cpu()`가 현재 thread의 `recent_cpu * 100` 값을 nearest rounding으로 반환하도록 구현했습
  니다.
### 이번 이슈 범위 외 변경사항
  - `load_avg`, `ready_threads`를 헤더의 `static` 선언에서 제거하고 `thread.c`의 단일 전역 상태로 이동했습니
  다.
  - fixed-point helper 관련 주석을 정리했습니다.

  ## 테스트 방법

  1. `thread_get_load_avg()`와 `thread_get_recent_cpu()`가 더 이상 더미값 `0`을 반환하지 않는지 코드로 확인했
  습니다.
  2. `load_avg`, `recent_cpu` 반환 시 fixed-point 값에 `100`을 곱한 뒤 `fixed_to_int_nearest()`를 적용하는지
  확인했습니다.

  ## 리뷰어가 확인할 것

  - [ ] 변경 범위가 issue #54의 `recent_cpu/load_avg` 조회 API 구현에 맞는가?
  - [ ] `load_avg`가 시스템 전체에서 하나의 전역 상태로 관리되는가?
  - [ ] `thread_get_load_avg()`와 `thread_get_recent_cpu()`가 `* 100` 후 nearest rounding을 적용하는가?
  - [ ] MLFQS 후속 이슈에서 사용할 수 있는 형태로 구현되어 있는가?

  ## 관련 이슈

  Closes #54