### PR TITLE
feat: 모든 스레드를 관리하는 all_list 구현

### DIFF
--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -36,6 +36,7 @@ static bool priority_isless(const struct list_elem* a ,const struct list_elem* b
 	return thread_a->priority>thread_b->priority;
 }
 static struct list sleep_list;
+static struct list all_list;
 
 
 
@@ -131,6 +132,7 @@ thread_init (void) {
 
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
+	list_init (&all_list);
 	list_init (&ready_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
@@ -319,6 +321,7 @@ thread_exit (void) {
 	/* Just set our status to dying and schedule another process.
 	   We will be destroyed during the call to schedule_tail(). */
 	intr_disable ();
+	list_remove(&(thread_current ()->all_elem));
 	do_schedule (THREAD_DYING);
 	NOT_REACHED ();
 }
@@ -448,6 +451,12 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 	//스레드의 기본 nice=0, recent_cpu=0;
 	t->nice = t->recent_cpu = 0;
+
+	enum intr_level old_level = intr_disable ();	/* interrupt 방해금지모드 설정 */
+
+	list_push_back(&all_list, &(t->all_elem));
+
+	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 	
 }
 


### PR DESCRIPTION
## 변경 사항

- `thread.c`에서 all_list를 추가하기 위해서 thread_init, init_thread, thread_exit 함수에서 all_list element의 등록/제거 기능을 추가했습니다.

## 테스트 방법

  ## 리뷰어가 확인할 것

  - [ ] 변경 범위가 의도한 폴더 안으로 제한되어 있는가?
  - [ ] 작업 내용이 issue와 맞는가?
  - [ ] `all_list`가 `ready_list`, `sleep_list`, semaphore waiters와 별도 `list_elem`을 사용하는가?
  - [ ] `initial_thread`와 새 thread가 모두 `all_list`에 포함되는가?
  - [ ] 종료되는 thread가 `all_list`에서 제거되는가?

## 관련 이슈

Closes #66 