### PR TITLE
Issus 59 mlfqs 모드에서 직접 priority 설정과 donation 분리

### DIFF
--- a/pintos/include/lib/kernel/list.h
+++ b/pintos/include/lib/kernel/list.h
@@ -153,6 +153,9 @@ void list_sort (struct list *,
                 list_less_func *, void *aux);
 void list_insert_ordered (struct list *, struct list_elem *,
                           list_less_func *, void *aux);
+                          void
+list_mlfqs_insert (struct list mlfq[64], struct list_elem *,
+		                     int, void *aux);
 void list_unique (struct list *, struct list *duplicates,
                   list_less_func *, void *aux);
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -156,5 +156,8 @@ void do_iret (struct intr_frame *tf);
 
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
+struct list* high_Q(struct list *mlfqs);
+
+
 
 #endif /* threads/thread.h */

--- a/pintos/lib/kernel/list.c
+++ b/pintos/lib/kernel/list.c
@@ -434,16 +434,15 @@ list_insert_ordered (struct list *list, struct list_elem *elem,
 	mlfqs 전용 입력 생성
 */
 void
-list_mlfqs_insert (struct list **mlfq, struct list_elem *elems,
+list_mlfqs_insert (struct list mlfq[64], struct list_elem *elems,
 		int priority, void *aux UNUSED) {
-
-	struct list_elem **mlfque=mlfq;
 
 	ASSERT (mlfq != NULL);
 	ASSERT (elems != NULL);
-	ASSERT (priority != NULL);
+	if(priority>63) priority = 63;
+	if(priority<0) priority = 0;
 
-	return list_push_back (mlfq[priority], elems);
+	return list_push_back (&mlfq[priority], elems);
 }
 
 

--- a/pintos/lib/kernel/list.c
+++ b/pintos/lib/kernel/list.c
@@ -430,6 +430,23 @@ list_insert_ordered (struct list *list, struct list_elem *elem,
 	return list_insert (e, elem);
 }
 
+/* 
+	mlfqs 전용 입력 생성
+*/
+void
+list_mlfqs_insert (struct list **mlfq, struct list_elem *elems,
+		int priority, void *aux UNUSED) {
+
+	struct list_elem **mlfque=mlfq;
+
+	ASSERT (mlfq != NULL);
+	ASSERT (elems != NULL);
+	ASSERT (priority != NULL);
+
+	return list_push_back (mlfq[priority], elems);
+}
+
+
 /* Iterates through LIST and removes all but the first in each
    set of adjacent elements that are equal according to LESS
    given auxiliary data AUX.  If DUPLICATES is non-null, then the

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -296,7 +296,7 @@ thread_unblock (struct thread *t) {
 	if (thread_mlfqs)
 	{
 		//mlfq[priority]에 삽입
-		list_mlfqs_insert (&mlfq, &t->elem, t->priority, NULL);
+		list_mlfqs_insert (mlfq, &t->elem, t->priority, NULL);
 	}
 	else
 	{
@@ -369,7 +369,7 @@ thread_yield (void) {
 		if (thread_mlfqs)
 		{
 			//mlfq[priority]에 삽입
-			list_mlfqs_insert (&mlfq, &curr->elem, curr->priority, NULL);
+			list_mlfqs_insert (mlfq, &curr->elem, curr->priority, NULL);
 		}
 
 		else
@@ -438,11 +438,14 @@ thread_set_nice (int nice) {
 
 	//thread_set_priority를 사용할 수 없기에 수정
 	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry (list_begin(high_Q(mlfq)), struct thread, elem);
-	if(thread_begin->priority > new_priority)
-	{
+	struct list *list_be = high_Q(mlfq);
+	if(!list_empty(list_be)){
+		struct thread* thread_begin = list_entry (list_begin(list_be), struct thread, elem);
+		if(thread_begin->priority > new_priority)
+		{
 
-		thread_yield ();
+			thread_yield ();
+		}
 	}
 
 }
@@ -765,7 +768,7 @@ thread_wakeup () {
 		{
 			if(t->priority > thread_current()->priority)
 			{
-				thread_yield();
+				intr_yield_on_return();
 			}
 		}
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -290,7 +290,16 @@ thread_unblock (struct thread *t) {
 	ASSERT (t->status == THREAD_BLOCKED);
 	//list_push_back (&ready_list, &t->elem);
 	void *aux=NULL;
-	list_insert_ordered(&ready_list, &t->elem,priority_isless,aux);
+
+	if (thread_mlfqs)
+	{
+		//mlfq[priority]에 삽입
+		list_mlfqs_insert (&mlfq, &t->elem, t->priority, NULL);
+	}
+	else
+	{
+		list_insert_ordered(&ready_list, &t->elem, priority_isless, aux);
+	}
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -352,10 +361,21 @@ thread_yield (void) {
 	ASSERT (!intr_context ());
 
 	old_level = intr_disable ();
-	if (curr != idle_thread){
-		//list_push_back (&ready_list, &curr->elem);
-		void *aux=NULL;
-		list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+	if (curr != idle_thread)
+	{
+
+		if (thread_mlfqs)
+		{
+			//mlfq[priority]에 삽입
+			list_mlfqs_insert (&mlfq, &curr->elem, curr->priority, NULL);
+		}
+
+		else
+		{
+			void *aux=NULL;
+			list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+		}
+
 	}
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
@@ -717,6 +737,15 @@ thread_wakeup () {
 		list_pop_front (&sleep_list);
 
 		thread_unblock (t);
+
+		if (thread_mlfqs)
+		{
+			if(t->priority > thread_current()->priority)
+			{
+				thread_yield();
+			}
+		}
+
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -132,7 +132,10 @@ thread_init (void) {
 
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
-	list_init (&ready_list);
+	if (!thread_mlfqs)
+	{
+		list_init (&ready_list);
+	}
 	list_init (&sleep_list);
 	list_init (&destruction_req);
 	
@@ -144,7 +147,6 @@ thread_init (void) {
 		{
 			list_init(&mlfq[i]);
 		}
-
 		//스레드 개수와 load_avg의 값을 0으로 초기화
 		ready_threads = load_avg = 0;
 	}
@@ -288,7 +290,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	//list_push_back (&ready_list, &t->elem);
+
 	void *aux=NULL;
 
 	if (thread_mlfqs)
@@ -399,18 +401,14 @@ thread_set_priority (int new_priority) {
 /* Returns the current thread's priority. */
 int
 thread_get_priority (void) {
-	return thread_current ()->priority;
-}
 
-/* Sets the current thread's nice value to NICE. */
-void
-thread_set_nice (int nice) {
+	//thread_mlfqs 아니면
+	if (!thread_mlfqs)
+	{
+		return thread_current ()->priority;
+	}
 
-	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
 	struct thread* thread_curr = thread_current ();
-	thread_curr ->nice = nice;
-
-	//new_priority=PRI_MAX-recent_cpu/4-nice*2
 	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
 	new_priority = fixed_to_int_zero (new_priority);
 
@@ -422,13 +420,29 @@ thread_set_nice (int nice) {
 	{
 		new_priority = 0;
 	}
+	
+	return new_priority;
+
+}
+
+/* Sets the current thread's nice value to NICE. */
+void
+thread_set_nice (int nice) {
+
+	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
+	struct thread* thread_curr = thread_current ();
+	thread_curr ->nice = nice;
+
+	//new_priority=PRI_MAX-recent_cpu/4-nice*2
+	int new_priority = thread_get_priority ();
 
 	//thread_set_priority를 사용할 수 없기에 수정
 	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+	struct thread* thread_begin = list_entry (list_begin(high_Q(mlfq)), struct thread, elem);
 	if(thread_begin->priority > new_priority)
 	{
-		thread_yield();
+
+		thread_yield ();
 	}
 
 }
@@ -531,10 +545,19 @@ init_thread (struct thread *t, const char *name, int priority) {
    idle_thread. */
 static struct thread *
 next_thread_to_run (void) {
+	if (thread_mlfqs)
+	{
+		struct list *high_list = high_Q(mlfq);
+		if (list_empty (high_list))
+		return idle_thread;
+	else
+		return list_entry (list_pop_front (high_list), struct thread, elem);
+	}
 	if (list_empty (&ready_list))
 		return idle_thread;
 	else
 		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+	
 }
 
 /* Use iretq to launch the thread */
@@ -749,6 +772,22 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
+
+struct list*
+high_Q(struct list* mlfqs)
+{
+	for(int i = PRI_MAX; i >=PRI_MIN ; i++)
+	{
+		if(!list_empty(&mlfqs[i]))
+		{
+			//우선 순위 위부터 탐색
+			return &mlfqs[i];
+		}
+	}
+	return &mlfqs[PRI_MAX];
+
+}
+
 
 fixed_t 
 fixed_convert (int n) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -29,13 +29,15 @@
 static struct list ready_list;
 static bool priority_isless(const struct list_elem* a ,const struct list_elem* b,void* aux)
 {
-	struct thread* thread_a = list_entry(a,struct thread,elem);
-	struct thread* thread_b = list_entry(b,struct thread,elem);
+	struct thread* thread_a = list_entry(a, struct thread, elem);
+	struct thread* thread_b = list_entry(b, struct thread, elem);
 
 
-	return thread_a->priority>thread_b->priority;
+	return thread_a->priority > thread_b->priority;
 }
 static struct list sleep_list;
+
+static struct list mlfq[64];
 
 
 
@@ -133,8 +135,20 @@ thread_init (void) {
 	list_init (&ready_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
-	//스레드 개수와 load_avg의 값을 0으로 초기화
-	ready_threads = load_avg = 0;
+	
+
+	if (thread_mlfqs)
+	{
+		//mlfq 초기화
+		for (int i=0 ; i <= PRI_MAX ; i++)
+		{
+			list_init(&mlfq[i]);
+		}
+
+		//스레드 개수와 load_avg의 값을 0으로 초기화
+		ready_threads = load_avg = 0;
+	}
+
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
@@ -215,6 +229,12 @@ thread_create (const char *name, int priority,
 		return TID_ERROR;
 
 	/* Initialize thread. */
+
+	if (thread_mlfqs)
+	{
+		//mlfqs 모드에서는 새로 생성된 스레드의 우선도가 최상위
+		priority=PRI_MAX;
+	}
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
@@ -344,6 +364,10 @@ thread_yield (void) {
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
+	if (thread_mlfqs)
+	{
+		return ;
+	}
 	thread_current ()->priority = new_priority;
 	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
 	if(thread_begin->priority > new_priority)
@@ -463,9 +487,15 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
+	
+	if (thread_mlfqs)
+	{
 	//스레드의 기본 nice=0, recent_cpu=0;
 	t->nice = t->recent_cpu = 0;
 	
+	
+
+	}
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -403,7 +403,13 @@ thread_set_nice (int nice) {
 		new_priority = 0;
 	}
 
-	thread_set_priority(new_priority);
+	//thread_set_priority를 사용할 수 없기에 수정
+	thread_current ()->priority = new_priority;
+	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+	if(thread_begin->priority > new_priority)
+	{
+		thread_yield();
+	}
 
 }
 


### PR DESCRIPTION
## 변경 사항

- MLFQS 모드에서 `thread_set_priority()`가 직접 priority를 변경하지 않도록 분리했습니다.
- MLFQS 모드에서 `thread_create()`의 priority 인자가 스케줄링에 직접 개입하지 않도록 처리했습니다.
- MLFQS용 priority queue 배열과 가장 높은 non-empty queue를 찾는 `high_Q()`를 추가했습니다.
- MLFQS ready queue 삽입 함수 `list_mlfqs_insert()`를 추가했습니다.
- timer interrupt 경로에서 직접 `thread_yield()`를 호출하지 않도록 `intr_yield_on_return()`으로 변경했습니다.

## 테스트 방법

1. MLFQS 모드에서 manual priority 설정 경로가 무시되는지 코드로 확인했습니다.
2. MLFQS ready queue 삽입/선택 경로에서 포인터 타입이 맞는지 확인했습니다.
3. `pintos/` 폴더가 수정되지 않았는지 확인합니다.

## 리뷰어가 확인할 것

- [ ] 변경 범위가 의도한 폴더 안으로 제한되어 있는가?
- [ ] 작업 내용이 issue와 맞는가?
- [ ] 문서 내용이 읽기 좋은가?
- [ ] 오타나 이상한 표현이 없는가?
- [ ] MLFQS 모드에서 `thread_set_priority()`가 priority를 직접 덮어쓰지 않는가?
- [ ] MLFQS ready queue 배열 삽입/선택 로직이 의도대로 동작하는가?

## 관련 이슈

Closes #59
