### PR TITLE
Issue 57 매 4 tick priority 갱신 구현

### DIFF
--- a/pintos/include/lib/kernel/list.h
+++ b/pintos/include/lib/kernel/list.h
@@ -153,6 +153,9 @@ void list_sort (struct list *,
                 list_less_func *, void *aux);
 void list_insert_ordered (struct list *, struct list_elem *,
                           list_less_func *, void *aux);
+                          void
+list_mlfqs_insert (struct list mlfq[64], struct list_elem *,
+		                     int, void *aux);
 void list_unique (struct list *, struct list *duplicates,
                   list_less_func *, void *aux);
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -157,7 +157,7 @@ void do_iret (struct intr_frame *tf);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
 struct list* high_Q(struct list *mlfqs);
-
+void priority_all_update(struct list mlfqs[64]);
 
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -156,5 +156,8 @@ void do_iret (struct intr_frame *tf);
 
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
+struct list* high_Q(struct list *mlfqs);
+
+
 
 #endif /* threads/thread.h */

--- a/pintos/lib/kernel/list.c
+++ b/pintos/lib/kernel/list.c
@@ -434,16 +434,15 @@ list_insert_ordered (struct list *list, struct list_elem *elem,
 	mlfqs 전용 입력 생성
 */
 void
-list_mlfqs_insert (struct list **mlfq, struct list_elem *elems,
+list_mlfqs_insert (struct list mlfq[64], struct list_elem *elems,
 		int priority, void *aux UNUSED) {
-
-	struct list_elem **mlfque=mlfq;
 
 	ASSERT (mlfq != NULL);
 	ASSERT (elems != NULL);
-	ASSERT (priority != NULL);
+	if(priority>63) priority = 63;
+	if(priority<0) priority = 0;
 
-	return list_push_back (mlfq[priority], elems);
+	return list_push_back (&mlfq[priority], elems);
 }
 
 

--- a/pintos/lib/kernel/list.c
+++ b/pintos/lib/kernel/list.c
@@ -430,6 +430,23 @@ list_insert_ordered (struct list *list, struct list_elem *elem,
 	return list_insert (e, elem);
 }
 
+/* 
+	mlfqs 전용 입력 생성
+*/
+void
+list_mlfqs_insert (struct list **mlfq, struct list_elem *elems,
+		int priority, void *aux UNUSED) {
+
+	struct list_elem **mlfque=mlfq;
+
+	ASSERT (mlfq != NULL);
+	ASSERT (elems != NULL);
+	ASSERT (priority != NULL);
+
+	return list_push_back (mlfq[priority], elems);
+}
+
+
 /* Iterates through LIST and removes all but the first in each
    set of adjacent elements that are equal according to LESS
    given auxiliary data AUX.  If DUPLICATES is non-null, then the

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -296,7 +296,7 @@ thread_unblock (struct thread *t) {
 	if (thread_mlfqs)
 	{
 		//mlfq[priority]에 삽입
-		list_mlfqs_insert (&mlfq, &t->elem, t->priority, NULL);
+		list_mlfqs_insert (mlfq, &t->elem, t->priority, NULL);
 	}
 	else
 	{
@@ -369,7 +369,7 @@ thread_yield (void) {
 		if (thread_mlfqs)
 		{
 			//mlfq[priority]에 삽입
-			list_mlfqs_insert (&mlfq, &curr->elem, curr->priority, NULL);
+			list_mlfqs_insert (mlfq, &curr->elem, curr->priority, NULL);
 		}
 
 		else
@@ -438,11 +438,14 @@ thread_set_nice (int nice) {
 
 	//thread_set_priority를 사용할 수 없기에 수정
 	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry (list_begin(high_Q(mlfq)), struct thread, elem);
-	if(thread_begin->priority > new_priority)
-	{
+	struct list *list_be = high_Q(mlfq);
+	if(!list_empty(list_be)){
+		struct thread* thread_begin = list_entry (list_begin(list_be), struct thread, elem);
+		if(thread_begin->priority > new_priority)
+		{
 
-		thread_yield ();
+			thread_yield ();
+		}
 	}
 
 }
@@ -765,7 +768,7 @@ thread_wakeup () {
 		{
 			if(t->priority > thread_current()->priority)
 			{
-				thread_yield();
+				intr_yield_on_return();
 			}
 		}
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -290,7 +290,16 @@ thread_unblock (struct thread *t) {
 	ASSERT (t->status == THREAD_BLOCKED);
 	//list_push_back (&ready_list, &t->elem);
 	void *aux=NULL;
-	list_insert_ordered(&ready_list, &t->elem,priority_isless,aux);
+
+	if (thread_mlfqs)
+	{
+		//mlfq[priority]에 삽입
+		list_mlfqs_insert (&mlfq, &t->elem, t->priority, NULL);
+	}
+	else
+	{
+		list_insert_ordered(&ready_list, &t->elem, priority_isless, aux);
+	}
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -352,10 +361,21 @@ thread_yield (void) {
 	ASSERT (!intr_context ());
 
 	old_level = intr_disable ();
-	if (curr != idle_thread){
-		//list_push_back (&ready_list, &curr->elem);
-		void *aux=NULL;
-		list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+	if (curr != idle_thread)
+	{
+
+		if (thread_mlfqs)
+		{
+			//mlfq[priority]에 삽입
+			list_mlfqs_insert (&mlfq, &curr->elem, curr->priority, NULL);
+		}
+
+		else
+		{
+			void *aux=NULL;
+			list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+		}
+
 	}
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
@@ -717,6 +737,15 @@ thread_wakeup () {
 		list_pop_front (&sleep_list);
 
 		thread_unblock (t);
+
+		if (thread_mlfqs)
+		{
+			if(t->priority > thread_current()->priority)
+			{
+				thread_yield();
+			}
+		}
+
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -132,7 +132,10 @@ thread_init (void) {
 
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
-	list_init (&ready_list);
+	if (!thread_mlfqs)
+	{
+		list_init (&ready_list);
+	}
 	list_init (&sleep_list);
 	list_init (&destruction_req);
 	
@@ -144,7 +147,6 @@ thread_init (void) {
 		{
 			list_init(&mlfq[i]);
 		}
-
 		//스레드 개수와 load_avg의 값을 0으로 초기화
 		ready_threads = load_avg = 0;
 	}
@@ -288,7 +290,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	//list_push_back (&ready_list, &t->elem);
+
 	void *aux=NULL;
 
 	if (thread_mlfqs)
@@ -399,18 +401,14 @@ thread_set_priority (int new_priority) {
 /* Returns the current thread's priority. */
 int
 thread_get_priority (void) {
-	return thread_current ()->priority;
-}
 
-/* Sets the current thread's nice value to NICE. */
-void
-thread_set_nice (int nice) {
+	//thread_mlfqs 아니면
+	if (!thread_mlfqs)
+	{
+		return thread_current ()->priority;
+	}
 
-	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
 	struct thread* thread_curr = thread_current ();
-	thread_curr ->nice = nice;
-
-	//new_priority=PRI_MAX-recent_cpu/4-nice*2
 	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
 	new_priority = fixed_to_int_zero (new_priority);
 
@@ -422,13 +420,29 @@ thread_set_nice (int nice) {
 	{
 		new_priority = 0;
 	}
+	
+	return new_priority;
+
+}
+
+/* Sets the current thread's nice value to NICE. */
+void
+thread_set_nice (int nice) {
+
+	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
+	struct thread* thread_curr = thread_current ();
+	thread_curr ->nice = nice;
+
+	//new_priority=PRI_MAX-recent_cpu/4-nice*2
+	int new_priority = thread_get_priority ();
 
 	//thread_set_priority를 사용할 수 없기에 수정
 	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+	struct thread* thread_begin = list_entry (list_begin(high_Q(mlfq)), struct thread, elem);
 	if(thread_begin->priority > new_priority)
 	{
-		thread_yield();
+
+		thread_yield ();
 	}
 
 }
@@ -531,10 +545,19 @@ init_thread (struct thread *t, const char *name, int priority) {
    idle_thread. */
 static struct thread *
 next_thread_to_run (void) {
+	if (thread_mlfqs)
+	{
+		struct list *high_list = high_Q(mlfq);
+		if (list_empty (high_list))
+		return idle_thread;
+	else
+		return list_entry (list_pop_front (high_list), struct thread, elem);
+	}
 	if (list_empty (&ready_list))
 		return idle_thread;
 	else
 		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+	
 }
 
 /* Use iretq to launch the thread */
@@ -749,6 +772,22 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
+
+struct list*
+high_Q(struct list* mlfqs)
+{
+	for(int i = PRI_MAX; i >=PRI_MIN ; i++)
+	{
+		if(!list_empty(&mlfqs[i]))
+		{
+			//우선 순위 위부터 탐색
+			return &mlfqs[i];
+		}
+	}
+	return &mlfqs[PRI_MAX];
+
+}
+
 
 fixed_t 
 fixed_convert (int n) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -29,13 +29,15 @@
 static struct list ready_list;
 static bool priority_isless(const struct list_elem* a ,const struct list_elem* b,void* aux)
 {
-	struct thread* thread_a = list_entry(a,struct thread,elem);
-	struct thread* thread_b = list_entry(b,struct thread,elem);
+	struct thread* thread_a = list_entry(a, struct thread, elem);
+	struct thread* thread_b = list_entry(b, struct thread, elem);
 
 
-	return thread_a->priority>thread_b->priority;
+	return thread_a->priority > thread_b->priority;
 }
 static struct list sleep_list;
+
+static struct list mlfq[64];
 
 
 
@@ -133,8 +135,20 @@ thread_init (void) {
 	list_init (&ready_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
-	//스레드 개수와 load_avg의 값을 0으로 초기화
-	ready_threads = load_avg = 0;
+	
+
+	if (thread_mlfqs)
+	{
+		//mlfq 초기화
+		for (int i=0 ; i <= PRI_MAX ; i++)
+		{
+			list_init(&mlfq[i]);
+		}
+
+		//스레드 개수와 load_avg의 값을 0으로 초기화
+		ready_threads = load_avg = 0;
+	}
+
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
@@ -215,6 +229,12 @@ thread_create (const char *name, int priority,
 		return TID_ERROR;
 
 	/* Initialize thread. */
+
+	if (thread_mlfqs)
+	{
+		//mlfqs 모드에서는 새로 생성된 스레드의 우선도가 최상위
+		priority=PRI_MAX;
+	}
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
@@ -344,6 +364,10 @@ thread_yield (void) {
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
+	if (thread_mlfqs)
+	{
+		return ;
+	}
 	thread_current ()->priority = new_priority;
 	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
 	if(thread_begin->priority > new_priority)
@@ -463,9 +487,15 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
+	
+	if (thread_mlfqs)
+	{
 	//스레드의 기본 nice=0, recent_cpu=0;
 	t->nice = t->recent_cpu = 0;
 	
+	
+
+	}
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -403,7 +403,13 @@ thread_set_nice (int nice) {
 		new_priority = 0;
 	}
 
-	thread_set_priority(new_priority);
+	//thread_set_priority를 사용할 수 없기에 수정
+	thread_current ()->priority = new_priority;
+	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+	if(thread_begin->priority > new_priority)
+	{
+		thread_yield();
+	}
 
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -39,8 +39,6 @@ static struct list sleep_list;
 
 static struct list mlfq[64];
 
-
-
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -80,7 +78,7 @@ static void schedule (void);
 static tid_t allocate_tid (void);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
-
+static struct list temp_mlfqs[64];
 
 /* MLFQS에서 사용하는 Fixed Point 연산을 위한 helper functions */
 fixed_t fixed_convert (int);
@@ -192,8 +190,18 @@ thread_tick (void) {
 
 	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)
+	{
 		intr_yield_on_return ();
+		if(thread_mlfqs)
+		{
+			enum intr_level old_level;
+			old_level = intr_disable ();
+			priority_all_update(mlfq);
+			intr_set_level (old_level);
+		}
+	}
 }
+
 
 /* Prints thread statistics. */
 void
@@ -412,13 +420,13 @@ thread_get_priority (void) {
 	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
 	new_priority = fixed_to_int_zero (new_priority);
 
-	if(new_priority > 63)
+	if(new_priority > PRI_MAX)
 	{
-		new_priority = 63;
+		new_priority = PRI_MAX;
 	}
-	if(new_priority < 0)
+	if(new_priority < PRI_MIN)
 	{
-		new_priority = 0;
+		new_priority = PRI_MIN;
 	}
 	
 	return new_priority;
@@ -775,11 +783,55 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
+void priority_all_update(struct list mlfqs[64]){
+
+
+	for(int i = 0 ; i <= PRI_MAX ; i++)
+	{
+		list_init(&temp_mlfqs[i]);
+	}
+
+	for(int i = 0 ; i <= PRI_MAX ; i++){
+
+		struct list_elem *e;
+		while (!list_empty(&mlfqs[i]))
+		{
+			e=list_pop_front(&mlfqs[i]);
+			struct thread *nowthread = list_entry(e, struct thread, elem);
+			int new_priority = fixed_convert (PRI_MAX) - nowthread->recent_cpu/4 - fixed_convert (nowthread->nice) * 2;
+			new_priority = fixed_to_int_zero (new_priority);
+
+			if(new_priority > PRI_MAX)
+			{
+				new_priority = PRI_MAX;
+			}
+
+			if(new_priority < PRI_MIN)
+			{
+				new_priority = PRI_MIN;
+			}
+			if(nowthread->priority!=new_priority)
+			{
+				nowthread->priority=new_priority;
+			}
+			list_push_back (&temp_mlfqs[new_priority], e);
+		}
+	}
+	for(int i = 0 ; i <= PRI_MAX ; i++)
+	{
+    	while (!list_empty(&temp_mlfqs[i]))
+		{
+			struct list_elem *e = list_pop_front(&temp_mlfqs[i]);
+			list_push_back(&mlfqs[i], e);
+		}
+	}
+}
+
 
 struct list*
 high_Q(struct list* mlfqs)
 {
-	for(int i = PRI_MAX; i >=PRI_MIN ; i++)
+	for(int i = PRI_MAX; i >=PRI_MIN ; i--)
 	{
 		if(!list_empty(&mlfqs[i]))
 		{


### PR DESCRIPTION
## 변경 사항

- MLFQS 모드에서 4 tick마다 priority를 다시 계산하는 `priority_all_update()` 함수를 추가했습니다.
- MLFQS 공식 `PRI_MAX - recent_cpu / 4 - nice * 2`를 기준으로 priority를 계산하도록 했습니다.
- 계산된 priority가 `PRI_MIN`보다 작거나 `PRI_MAX`보다 커지지 않도록 범위 제한을 추가했습니다.
- priority가 바뀐 ready thread를 새로운 priority에 맞는 MLFQ ready queue로 다시 배치하도록 했습니다.
- 이전 issue 59 내용에서 잘못된 점을 고쳤습니다.

## 테스트 방법

1. `pintos/threads`에서 `make clean && make`를 실행해 빌드가 되는지 확인합니다.
2. MLFQS 관련 테스트를 실행해 priority 갱신 로직이 동작하는지 확인합니다.
3. `pintos/` 폴더가 수정되지 않았는지 확인합니다.

## 리뷰어가 확인할 것

- [x] 변경 범위가 issue 57의 priority 갱신 로직 안으로 제한되어 있는가?
- [x] MLFQS priority 공식이 문서 기준과 맞는가?
- [x] priority가 항상 `PRI_MIN` 이상 `PRI_MAX` 이하로 제한되는가?
- [ ] 4 tick마다 priority 갱신 함수가 호출되는가?
- [ ] ready queue 재배치가 priority 계산 결과를 반영하는가?
- [ ] 문서 내용이 읽기 좋은가?
- [ ] 오타나 이상한 표현이 없는가?

## 관련 이슈

Closes #57
