### PR TITLE
feat: update recent_cpu per tick

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -120,7 +120,7 @@ void
 timer_print_stats (void) {
 	printf ("Timer: %"PRId64" ticks\n", timer_ticks ());
 }
-
+
 /* Timer interrupt handler. */
 static void
 timer_interrupt (struct intr_frame *args UNUSED) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -175,6 +175,10 @@ thread_tick (void) {
 #endif
 	else
 		kernel_ticks++;
+		
+	if (t != idle_thread && thread_mlfqs == true) {
+		t->recent_cpu += fixed_convert (1);
+	}
 
 	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)


### PR DESCRIPTION
## 변경 사항

-  `thread.c` 에서 idle 이 아닌 스레드의 recent_cpu 값을 증가하도록 변경했습니다.
- 
### 작업 범위 외 변경사항

- `timer.c`의 form-feed 문자를 제거 했습니다.

## 테스트 방법

1. `therad_mlfqs`변수가 `true`일 때에만 recent_cpu 값을 증가시키는지 확인했습니다.
2. `recent_cpu`는 fixed_t이기 때문에 1을 더할 때 fixed_convert 된 값을 더했는지 확인했습니다.

## 리뷰어가 확인할 것

- [ ] `therad_mlfqs`변수가 `true`일 때에만 recent_cpu 값을 증가시키는가?
- [ ] idle thread는 `recent_cpu` 증가 대상에서 제외되는가?
- [ ] `recent_cpu`는 fixed_t이기 때문에 1을 더할 때 fixed_convert 된 값을 더하는가?

## 관련 이슈

Closes #55 