### PR TITLE
feat: Project 3 Synchronization 대기열 우선순위 적용Issue 50 sync applied priority

### DIFF
--- a/pintos/threads/Makefile
+++ b/pintos/threads/Makefile
@@ -9,9 +9,17 @@ ALARM_TESTS = tests/threads/alarm-single \
 
 ALARM_RESULTS = $(addprefix build/,$(addsuffix .result,$(ALARM_TESTS)))
 
+SYNC_TESTS = tests/threads/priority-sema \
+	tests/threads/priority-condvar \
+	tests/threads/priority-donate-sema
+
+SYNC_RESULTS = $(addprefix build/,$(addsuffix .result,$(SYNC_TESTS)))
+
 .PHONY: alarm alarm-tests alarm-check alarm-clean \
 	alarm-single alarm-multiple alarm-simultaneous \
-	alarm-priority alarm-zero alarm-negative
+	alarm-priority alarm-zero alarm-negative \
+	Sync sync sync-tests sync-check sync-clean \
+	priority-sema priority-condvar priority-donate-sema
 
 alarm:
 	$(MAKE) alarm-clean
@@ -62,3 +70,46 @@ alarm-zero:
 
 alarm-negative:
 	$(MAKE) build/tests/threads/alarm-negative.result
+
+Sync: sync
+
+sync:
+	$(MAKE) sync-clean
+	$(MAKE) sync-check
+
+# Build only the result files for the synchronization priority tests.
+sync-tests: $(SYNC_RESULTS)
+
+# Print PASS/FAIL output for the synchronization priority tests only.
+sync-check: sync-tests
+	@failures=0; count=0; \
+	for test in $(SYNC_TESTS); do \
+		count=$$((count + 1)); \
+		if echo PASS | cmp -s build/$$test.result -; then \
+			echo "pass $$test"; \
+		else \
+			echo "FAIL $$test"; \
+			failures=$$((failures + 1)); \
+		fi; \
+	done; \
+	if [ $$failures -eq 0 ]; then \
+		echo "All $$count synchronization tests passed."; \
+	else \
+		echo "$$failures of $$count synchronization tests failed."; \
+		exit 1; \
+	fi
+
+# Remove only the generated artifacts for the synchronization priority tests.
+sync-clean:
+	rm -f $(addprefix build/,$(addsuffix .result,$(SYNC_TESTS)))
+	rm -f $(addprefix build/,$(addsuffix .output,$(SYNC_TESTS)))
+	rm -f $(addprefix build/,$(addsuffix .errors,$(SYNC_TESTS)))
+
+priority-sema:
+	$(MAKE) build/tests/threads/priority-sema.result
+
+priority-condvar:
+	$(MAKE) build/tests/threads/priority-condvar.result
+
+priority-donate-sema:
+	$(MAKE) build/tests/threads/priority-donate-sema.result

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -32,6 +32,15 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
+static bool priority_isless(const struct list_elem* a ,const struct list_elem* b,void* aux)
+{
+	struct thread* thread_a = list_entry(a,struct thread,elem);
+	struct thread* thread_b = list_entry(b,struct thread,elem);
+
+
+	return thread_a->priority>thread_b->priority;
+}
+
 /* Initializes semaphore SEMA to VALUE.  A semaphore is a
    nonnegative integer along with two atomic operators for
    manipulating it:
@@ -66,7 +75,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_insert_ordered(&(sema->waiters), &thread_current()->elem,priority_isless(), NULL);
+		list_insert_ordered(&(sema->waiters), &thread_current()->elem, priority_isless, NULL);
 		thread_block ();
 	}
 	sema->value--;

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -66,7 +66,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered(&(sema->waiters), &thread_current()->elem,priority_isless(), NULL);
 		thread_block ();
 	}
 	sema->value--;

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -32,10 +32,10 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
-static bool priority_isless(const struct list_elem* a ,const struct list_elem* b,void* aux)
+static bool priority_more_func(const struct list_elem* a ,const struct list_elem* b,void* aux)
 {
-	struct thread* thread_a = list_entry(a,struct thread,semaphore_elem->semaphore->elem);
-	struct thread* thread_b = list_entry(b,struct thread,semaphore_elem->semaphore->elem);
+	struct thread* thread_a = list_entry(a,struct thread,elem);
+	struct thread* thread_b = list_entry(b,struct thread,elem);
 
 	return thread_a->priority>thread_b->priority;
 }
@@ -74,7 +74,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_insert_ordered(&(sema->waiters), &thread_current()->elem, priority_isless, NULL);
+		list_insert_ordered(&(sema->waiters), &thread_current()->elem, priority_more_func, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -118,7 +118,7 @@ sema_up (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	if (!list_empty (&sema->waiters)){
-		list_sort (&(sema->waiters), priority_isless, NULL);
+		list_sort (&(sema->waiters), priority_more_func, NULL);
 		thread_unblock (list_entry (list_pop_front (&sema->waiters), struct thread, elem));
 	}
 	sema->value++;
@@ -252,6 +252,20 @@ struct semaphore_elem {
 	struct semaphore semaphore;         /* This semaphore. */
 };
 
+static bool priority_more_semaphore_elem_func(const struct list_elem* semaphore_elem_elem_a,const struct list_elem* semaphore_elem_elem_b,void* aux)
+{
+	struct semaphore_elem* semaphore_elem_a = list_entry(semaphore_elem_elem_a, struct semaphore_elem, elem);
+	struct semaphore_elem* semaphore_elem_b = list_entry(semaphore_elem_elem_b, struct semaphore_elem, elem);
+
+	struct list_elem* thread_elem_a = list_front(&semaphore_elem_a->semaphore.waiters);
+	struct list_elem* thread_elem_b = list_front(&semaphore_elem_b->semaphore.waiters);
+
+	struct thread* thread_a = list_entry(thread_elem_a, struct thread, elem);
+	struct thread* thread_b = list_entry(thread_elem_b, struct thread, elem);
+
+	return thread_a->priority>thread_b->priority;
+}
+
 /* Initializes condition variable COND.  A condition variable
    allows one piece of code to signal a condition and cooperating
    code to receive the signal and act upon it. */
@@ -294,7 +308,7 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	sema_init (&waiter.semaphore, 0);
 	//list_push_back (&cond->waiters, &waiter.elem);
 
-	list_insert_ordered(&cond->waiters, &waiter.elem, priority_isless, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
+	list_insert_ordered(&cond->waiters, &waiter.elem, priority_more_semaphore_elem_func, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
 	printf("[cond_wait] thread=%s pri=%d cond_waiters=%d\n", // 현재 스레드, 그스레드의 우선순위, 지금까지 몇명 들어왔는지
        thread_current()->name,
        thread_current()->priority,
@@ -328,7 +342,7 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	if (!list_empty (&cond->waiters)){
-		list_sort (&(cond->waiters), priority_isless, NULL); // list_sort(&정렬할_리스트, 비교함수, NULL);
+		list_sort (&(cond->waiters), priority_more_semaphore_elem_func, NULL); // list_sort(&정렬할_리스트, 비교함수, NULL);
 		
 
 		sema_up (&list_entry (list_pop_front (&cond->waiters),

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -324,7 +324,6 @@ cond_wait (struct condition *cond, struct lock *lock) {
    interrupt handler. */
 void
 cond_signal (struct condition *cond, struct lock *lock UNUSED) {
-	struct semaphore_elem waiter;
 	ASSERT (cond != NULL);
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -32,8 +32,7 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
-static bool priority_more_func(const struct list_elem* a ,const struct list_elem* b,void* aux)
-{
+static bool priority_more_func (const struct list_elem* a ,const struct list_elem* b,void* aux) {
 	struct thread* thread_a = list_entry(a,struct thread,elem);
 	struct thread* thread_b = list_entry(b,struct thread,elem);
 
@@ -74,7 +73,8 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_insert_ordered(&(sema->waiters), &thread_current()->elem, priority_more_func, NULL);
+		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered (&(sema->waiters), &thread_current()->elem, priority_more_func, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -252,9 +252,7 @@ struct semaphore_elem {
 	struct semaphore semaphore;         /* This semaphore. */
 };
 
-static bool priority_more_semaphore_elem_func(const struct list_elem* semaphore_elem_elem_a,const struct list_elem* semaphore_elem_elem_b,void* aux)
-{
-	
+static bool priority_more_semaphore_elem_func (const struct list_elem* semaphore_elem_elem_a,const struct list_elem* semaphore_elem_elem_b,void* aux) {
 	struct semaphore_elem* semaphore_elem_a = list_entry(semaphore_elem_elem_a, struct semaphore_elem, elem);
 	struct semaphore_elem* semaphore_elem_b = list_entry(semaphore_elem_elem_b, struct semaphore_elem, elem);
 
@@ -265,7 +263,6 @@ static bool priority_more_semaphore_elem_func(const struct list_elem* semaphore_
 	struct thread* thread_b = list_entry(thread_elem_b, struct thread, elem);
 
 	return thread_a->priority > thread_b->priority;
-
 }
 
 /* Initializes condition variable COND.  A condition variable
@@ -309,7 +306,7 @@ cond_wait (struct condition *cond, struct lock *lock) {
 
 	sema_init (&waiter.semaphore, 0);
 	list_push_back (&cond->waiters, &waiter.elem);
-	// list_insert_ordered(&cond->waiters, &waiter.elem, priority_more_semaphore_elem_func, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
+	// list_insert_ordered (&cond->waiters, &waiter.elem, priority_more_semaphore_elem_func, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -73,7 +73,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		// list_push_back (&sema->waiters, &thread_current ()->elem);
 		list_insert_ordered (&(sema->waiters), &thread_current()->elem, priority_more_func, NULL);
 		thread_block ();
 	}

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -293,7 +293,9 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
+	//list_push_back (&cond->waiters, &waiter.elem);
+
+	list_insert_ordered(&cond->waiters, &waiter.elem, priority_isless, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -309,18 +309,9 @@ cond_wait (struct condition *cond, struct lock *lock) {
 
 	sema_init (&waiter.semaphore, 0);
 	list_push_back (&cond->waiters, &waiter.elem);
-
 	// list_insert_ordered(&cond->waiters, &waiter.elem, priority_more_semaphore_elem_func, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
-	/* printf("[cond_wait] thread=%s pri=%d cond_waiters=%d\n", // 현재 스레드, 그스레드의 우선순위, 지금까지 몇명 들어왔는지
-       thread_current()->name,
-       thread_current()->priority,
-       (int) list_size(&cond->waiters)); */
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
-	/* printf("[cond_woke] thread=%s pri=%d\n", //
-       thread_current()->name,
-       thread_current()->priority); */
-
 	lock_acquire (lock);
 }
 
@@ -334,10 +325,6 @@ cond_wait (struct condition *cond, struct lock *lock) {
 void
 cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	struct semaphore_elem waiter;
-	/* printf("[cond_signal] current=%s pri=%d cond_waiters=%d \n", // 현재 스레드, 우선 순위, 몇 명 있는지
-       thread_current()->name,
-       thread_current()->priority,
-       (int) list_size(&cond->waiters)); */
 	ASSERT (cond != NULL);
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
@@ -345,8 +332,6 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 
 	if (!list_empty (&cond->waiters)){
 		list_sort (&(cond->waiters), priority_more_semaphore_elem_func, NULL); // list_sort(&정렬할_리스트, 비교함수, NULL);
-		
-
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
 	}

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -34,9 +34,8 @@
 
 static bool priority_isless(const struct list_elem* a ,const struct list_elem* b,void* aux)
 {
-	struct thread* thread_a = list_entry(a,struct thread,elem);
-	struct thread* thread_b = list_entry(b,struct thread,elem);
-
+	struct thread* thread_a = list_entry(a,struct thread,semaphore_elem->semaphore->elem);
+	struct thread* thread_b = list_entry(b,struct thread,semaphore_elem->semaphore->elem);
 
 	return thread_a->priority>thread_b->priority;
 }
@@ -295,9 +294,17 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	sema_init (&waiter.semaphore, 0);
 	//list_push_back (&cond->waiters, &waiter.elem);
 
-	list_insert_ordered(&cond->waiters, &waiter.elem, priority_isless, NULL);
+	list_insert_ordered(&cond->waiters, &waiter.elem, priority_isless, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
+	printf("[cond_wait] thread=%s pri=%d cond_waiters=%d\n", // 현재 스레드, 그스레드의 우선순위, 지금까지 몇명 들어왔는지
+       thread_current()->name,
+       thread_current()->priority,
+       (int) list_size(&cond->waiters));
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
+	printf("[cond_woke] thread=%s pri=%d\n", //
+       thread_current()->name,
+       thread_current()->priority);
+
 	lock_acquire (lock);
 }
 
@@ -310,13 +317,20 @@ cond_wait (struct condition *cond, struct lock *lock) {
    interrupt handler. */
 void
 cond_signal (struct condition *cond, struct lock *lock UNUSED) {
+	struct semaphore_elem waiter;
+	printf("[cond_signal] current=%s pri=%d cond_waiters=%d \n", // 현재 스레드, 우선 순위, 몇 명 있는지
+       thread_current()->name,
+       thread_current()->priority,
+       (int) list_size(&cond->waiters));
 	ASSERT (cond != NULL);
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
 	if (!list_empty (&cond->waiters)){
-		list_sort (&(cond->waiters), priority_isless, NULL);
+		list_sort (&(cond->waiters), priority_isless, NULL); // list_sort(&정렬할_리스트, 비교함수, NULL);
+		
+
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
 	}

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -118,11 +118,13 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	if (!list_empty (&sema->waiters)){
+		list_sort (&(sema->waiters), priority_isless, NULL);
+		thread_unblock (list_entry (list_pop_front (&sema->waiters), struct thread, elem));
+	}
 	sema->value++;
 	intr_set_level (old_level);
+	thread_yield();
 }
 
 static void sema_test_helper (void *sema_);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -315,9 +315,11 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
+	if (!list_empty (&cond->waiters)){
+		list_sort (&(cond->waiters), priority_isless, NULL);
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -254,6 +254,7 @@ struct semaphore_elem {
 
 static bool priority_more_semaphore_elem_func(const struct list_elem* semaphore_elem_elem_a,const struct list_elem* semaphore_elem_elem_b,void* aux)
 {
+	
 	struct semaphore_elem* semaphore_elem_a = list_entry(semaphore_elem_elem_a, struct semaphore_elem, elem);
 	struct semaphore_elem* semaphore_elem_b = list_entry(semaphore_elem_elem_b, struct semaphore_elem, elem);
 
@@ -263,7 +264,8 @@ static bool priority_more_semaphore_elem_func(const struct list_elem* semaphore_
 	struct thread* thread_a = list_entry(thread_elem_a, struct thread, elem);
 	struct thread* thread_b = list_entry(thread_elem_b, struct thread, elem);
 
-	return thread_a->priority>thread_b->priority;
+	return thread_a->priority > thread_b->priority;
+
 }
 
 /* Initializes condition variable COND.  A condition variable
@@ -306,18 +308,18 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	//list_push_back (&cond->waiters, &waiter.elem);
+	list_push_back (&cond->waiters, &waiter.elem);
 
-	list_insert_ordered(&cond->waiters, &waiter.elem, priority_more_semaphore_elem_func, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
-	printf("[cond_wait] thread=%s pri=%d cond_waiters=%d\n", // 현재 스레드, 그스레드의 우선순위, 지금까지 몇명 들어왔는지
+	// list_insert_ordered(&cond->waiters, &waiter.elem, priority_more_semaphore_elem_func, NULL); // list_insert_ordered(&리스트, &넣을_구조체->elem, 비교함수, NULL);
+	/* printf("[cond_wait] thread=%s pri=%d cond_waiters=%d\n", // 현재 스레드, 그스레드의 우선순위, 지금까지 몇명 들어왔는지
        thread_current()->name,
        thread_current()->priority,
-       (int) list_size(&cond->waiters));
+       (int) list_size(&cond->waiters)); */
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
-	printf("[cond_woke] thread=%s pri=%d\n", //
+	/* printf("[cond_woke] thread=%s pri=%d\n", //
        thread_current()->name,
-       thread_current()->priority);
+       thread_current()->priority); */
 
 	lock_acquire (lock);
 }
@@ -332,10 +334,10 @@ cond_wait (struct condition *cond, struct lock *lock) {
 void
 cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	struct semaphore_elem waiter;
-	printf("[cond_signal] current=%s pri=%d cond_waiters=%d \n", // 현재 스레드, 우선 순위, 몇 명 있는지
+	/* printf("[cond_signal] current=%s pri=%d cond_waiters=%d \n", // 현재 스레드, 우선 순위, 몇 명 있는지
        thread_current()->name,
        thread_current()->priority,
-       (int) list_size(&cond->waiters));
+       (int) list_size(&cond->waiters)); */
 	ASSERT (cond != NULL);
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());


### PR DESCRIPTION
## 작업 내용

- `sema_down()`에서 `sema->waiters`에 스레드를 priority 기준으로 삽입하도록 변경했습니다.
- `sema_up()`에서 `sema->waiters`를 priority 기준으로 정렬한 뒤, 가장 높은 priority의 스레드를 깨우도록 구현했습니다.
- `sema_up()` 이후 더 높은 priority의 스레드가 즉시 실행될 수 있도록 yield 흐름을 반영했습니다.
- `cond_signal()`에서 `cond->waiters`의 `semaphore_elem`을 기준으로 가장 높은 priority의 waiter를 선택하도록 구현했습니다.
- `cond_wait()`에서는 개인용 semaphore의 waiters가 아직 비어 있는 시점의 정렬 문제를 피하기 위해 `list_push_back()` 방식으로 등록하도록 정리했습니다.
- synchronization 관련 테스트를 한 번에 실행할 수 있도록 `make sync` / `make Sync` 타깃을 추가했습니다.

## 테스트

- [ ] `priority-sema`
- [ ] `priority-condvar`

## 참고 사항

- `sema->waiters`에는 `struct thread`의 `elem`이 들어갑니다.
- `cond->waiters`에는 `struct thread`가 아니라 `struct semaphore_elem`의 `elem`이 들어갑니다.
- `cond_signal()`에서는 `semaphore_elem` 내부의 semaphore waiters를 통해 실제 대기 중인 thread priority를 확인해야 합니다.

Closes #50
