### PR TITLE
feat: MLFQS 스케줄러 구현Feat/mlfqs

### DIFF
--- a/pintos/.vscode/pintos-test-history.json
+++ b/pintos/.vscode/pintos-test-history.json
@@ -1,0 +1,139 @@
+{
+  "threads": {
+    "tests/threads/alarm-single": {
+      "count": 7,
+      "last_used": 1777470208.802,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-multiple": {
+      "count": 6,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-simultaneous": {
+      "count": 6,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-priority": {
+      "count": 5,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-zero": {
+      "count": 5,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/alarm-negative": {
+      "count": 5,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-change": {
+      "count": 8,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-one": {
+      "count": 31,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-multiple": {
+      "count": 15,
+      "last_used": 1777522772.253,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-multiple2": {
+      "count": 11,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-nest": {
+      "count": 22,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-sema": {
+      "count": 11,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-lower": {
+      "count": 11,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-fifo": {
+      "count": 9,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-preempt": {
+      "count": 9,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-sema": {
+      "count": 9,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/priority-condvar": {
+      "count": 10,
+      "last_used": 1777470226.617,
+      "last_action": "run"
+    },
+    "tests/threads/priority-donate-chain": {
+      "count": 13,
+      "last_used": 1777469113.267,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-load-1": {
+      "count": 7,
+      "last_used": 1777470530.969,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-load-60": {
+      "count": 4,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-load-avg": {
+      "count": 4,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-recent-1": {
+      "count": 4,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-fair-2": {
+      "count": 4,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-fair-20": {
+      "count": 4,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-nice-2": {
+      "count": 3,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-nice-10": {
+      "count": 3,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    },
+    "tests/threads/mlfqs/mlfqs-block": {
+      "count": 3,
+      "last_used": 1777470592.388,
+      "last_action": "run"
+    }
+  }
+}

--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -120,7 +120,7 @@ void
 timer_print_stats (void) {
 	printf ("Timer: %"PRId64" ticks\n", timer_ticks ());
 }
-
+
 /* Timer interrupt handler. */
 static void
 timer_interrupt (struct intr_frame *args UNUSED) {

--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -128,6 +128,10 @@ timer_interrupt (struct intr_frame *args UNUSED) {
 	thread_tick ();
 
 	thread_wakeup ();
+
+	if (thread_mlfqs && (timer_ticks () % TIMER_FREQ == 0)) {
+		mlfqs_update_all_per_sec ();
+	}
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/pintos/include/lib/kernel/list.h
+++ b/pintos/include/lib/kernel/list.h
@@ -153,6 +153,9 @@ void list_sort (struct list *,
                 list_less_func *, void *aux);
 void list_insert_ordered (struct list *, struct list_elem *,
                           list_less_func *, void *aux);
+                          void
+list_mlfqs_insert (struct list mlfq[64], struct list_elem *,
+		                     int, void *aux);
 void list_unique (struct list *, struct list *duplicates,
                   list_less_func *, void *aux);
 

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -29,8 +29,13 @@ typedef int tid_t;
 #define PRI_MAX 63                      /* Highest priority. */
 
 /* MLFQS에서 사용하는 Fixed Point */
-typedef int64_t fixed_t;				/* 타입 이름 */
-#define FIXED_SCALE 1<<14;				
+typedef int fixed_t;				/* 타입 이름 */
+#define FIXED_SCALE (1<<14)		
+
+//load_avg, ready_threads 선언
+static fixed_t load_avg;
+static int ready_threads;
+
 
 /* A kernel thread or user process.
  *
@@ -100,6 +105,10 @@ struct thread {
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
 	struct list_elem sleep_elem;		/* Sleep List element. */
+	//recent_cpu, nice 선언
+	fixed_t recent_cpu;
+	int nice;
+
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -28,6 +28,10 @@ typedef int tid_t;
 #define PRI_DEFAULT 31                  /* Default priority. */
 #define PRI_MAX 63                      /* Highest priority. */
 
+/* MLFQS에서 사용하는 Fixed Point */
+typedef int64_t fixed_t;				/* 타입 이름 */
+#define FIXED_SCALE 1<<14;				
+
 /* A kernel thread or user process.
  *
  * Each thread structure is stored in its own 4 kB page.  The

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -29,8 +29,8 @@ typedef int tid_t;
 #define PRI_MAX 63                      /* Highest priority. */
 
 /* MLFQS에서 사용하는 Fixed Point */
-typedef int64_t fixed_t;				/* 타입 이름 */
-#define FIXED_SCALE 1<<14;				
+typedef int fixed_t;				/* 타입 이름 */
+#define FIXED_SCALE (1 << 14)
 
 /* A kernel thread or user process.
  *

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -99,6 +99,7 @@ struct thread {
 	int64_t wakeup_tick;				/* Record when this thread to wake up. (언제 깨워야 하는지 기록하는 변수) */
 
 	/* Shared between thread.c and synch.c. */
+	struct list_elem all_elem;          /* All List element. */
 	struct list_elem elem;              /* List element. */
 	struct list_elem sleep_elem;		/* Sleep List element. */
 	//recent_cpu, nice 선언

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -160,5 +160,7 @@ void thread_wakeup (void);
 struct list* high_Q(struct list *mlfqs);
 void priority_all_update(struct list mlfqs[64]);
 
+void mlfqs_update_all_per_sec(void);
+
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -157,7 +157,7 @@ void do_iret (struct intr_frame *tf);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
 struct list* high_Q(struct list *mlfqs);
-
+void priority_all_update(struct list mlfqs[64]);
 
 
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -32,6 +32,10 @@ typedef int tid_t;
 typedef int fixed_t;				/* 타입 이름 */
 #define FIXED_SCALE (1 << 14)
 
+//load_avg, ready_threads 선언
+static fixed_t load_avg;
+static int ready_threads;
+
 /* A kernel thread or user process.
  *
  * Each thread structure is stored in its own 4 kB page.  The

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -32,9 +32,6 @@ typedef int tid_t;
 typedef int fixed_t;				/* 타입 이름 */
 #define FIXED_SCALE (1 << 14)
 
-//load_avg, ready_threads 선언
-static fixed_t load_avg;
-static int ready_threads;
 
 /* A kernel thread or user process.
  *

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -156,5 +156,8 @@ void do_iret (struct intr_frame *tf);
 
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
+struct list* high_Q(struct list *mlfqs);
+
+
 
 #endif /* threads/thread.h */

--- a/pintos/lib/kernel/list.c
+++ b/pintos/lib/kernel/list.c
@@ -434,16 +434,15 @@ list_insert_ordered (struct list *list, struct list_elem *elem,
 	mlfqs 전용 입력 생성
 */
 void
-list_mlfqs_insert (struct list **mlfq, struct list_elem *elems,
+list_mlfqs_insert (struct list mlfq[64], struct list_elem *elems,
 		int priority, void *aux UNUSED) {
-
-	struct list_elem **mlfque=mlfq;
 
 	ASSERT (mlfq != NULL);
 	ASSERT (elems != NULL);
-	ASSERT (priority != NULL);
+	if(priority>63) priority = 63;
+	if(priority<0) priority = 0;
 
-	return list_push_back (mlfq[priority], elems);
+	return list_push_back (&mlfq[priority], elems);
 }
 
 

--- a/pintos/lib/kernel/list.c
+++ b/pintos/lib/kernel/list.c
@@ -430,6 +430,23 @@ list_insert_ordered (struct list *list, struct list_elem *elem,
 	return list_insert (e, elem);
 }
 
+/* 
+	mlfqs 전용 입력 생성
+*/
+void
+list_mlfqs_insert (struct list **mlfq, struct list_elem *elems,
+		int priority, void *aux UNUSED) {
+
+	struct list_elem **mlfque=mlfq;
+
+	ASSERT (mlfq != NULL);
+	ASSERT (elems != NULL);
+	ASSERT (priority != NULL);
+
+	return list_push_back (mlfq[priority], elems);
+}
+
+
 /* Iterates through LIST and removes all but the first in each
    set of adjacent elements that are equal according to LESS
    given auxiliary data AUX.  If DUPLICATES is non-null, then the

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -128,7 +128,7 @@ sema_up (struct semaphore *sema) {
 	enum intr_level old_level;
 
 	ASSERT (sema != NULL);
-
+	struct thread* t=NULL;
 	old_level = intr_disable ();
 	if (!list_empty (&sema->waiters)){
 		list_sort (&(sema->waiters), priority_more_func, NULL);
@@ -136,7 +136,9 @@ sema_up (struct semaphore *sema) {
 	}
 	sema->value++;
 	intr_set_level (old_level);
-	thread_yield();
+	if(t!=NULL&&t->priority > thread_current()->priority){
+		thread_yield();
+	}
 }
 
 static void sema_test_helper (void *sema_);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -856,6 +856,43 @@ high_Q(struct list* mlfqs)
 
 }
 
+void 
+mlfqs_update_all_per_sec(void) {
+	enum intr_level old_level;
+	old_level = intr_disable ();
+	
+	ready_threads = 0;
+	struct thread* t;
+
+	for (t = list_begin(&all_list); t != list_end(&all_list); t = list_next(t)) {
+		if (t == idle_thread) {
+			continue;
+		}
+		if (t->status == THREAD_RUNNING || t->status == THREAD_READY) {
+			ready_threads ++;
+		}
+	}
+
+	/*
+
+	load_avg = (59 / 60) * load_avg + (1 / 60) * ready_threads;
+	recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * recent_cpu + nice;
+
+	 */
+	load_avg = fixed_multiply(fixed_divide(fixed_convert(59), fixed_convert(60)), load_avg) 
+				+ fixed_multiply(fixed_divide(fixed_convert(1), fixed_convert(60)), fixed_convert(ready_threads));
+	
+	fixed_t coefficient = fixed_divide(fixed_multiply(fixed_convert(2), load_avg), (fixed_multiply(fixed_convert(2), load_avg) + fixed_convert(1)));
+	
+	for (t = list_begin(&all_list); t != list_end(&all_list); t = list_next(t)) {
+		if (t != idle_thread) {
+			t->recent_cpu = fixed_multiply(coefficient, t->recent_cpu) + fixed_convert(t->nice);	
+		}
+	}
+	intr_set_level (old_level);
+}
+
+
 
 fixed_t 
 fixed_convert (int n) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -1,5 +1,3 @@
-#define MLFQS
-
 #include "threads/thread.h"
 #include <debug.h>
 #include <stddef.h>
@@ -76,13 +74,11 @@ static tid_t allocate_tid (void);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
 
-#ifdef MLFQS
-	fixed_t fixed_convert (int);
-	fixed_t fixed_multiply (fixed_t,fixed_t);
-	fixed_t fixed_divide (fixed_t,fixed_t);
-	int fixed_to_int_zero (fixed_t);
-	int fixed_to_int_nearest (fixed_t);
-#endif
+fixed_t fixed_convert (int);
+fixed_t fixed_multiply (fixed_t,fixed_t);
+fixed_t fixed_divide (fixed_t,fixed_t);
+int fixed_to_int_zero (fixed_t);
+int fixed_to_int_nearest (fixed_t);
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -663,32 +659,31 @@ thread_wakeup () {
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
 
-#ifdef MLFQS
-	fixed_t 
-	fixed_convert (int n) {
 
-		return ((fixed_t) n) * FIXED_SCALE;
-	}
+fixed_t 
+fixed_convert (int n) {
 
-	fixed_t 
-	fixed_multiply (fixed_t x, fixed_t y) {
-		return (fixed_t) (((int64_t) x) * y / FIXED_SCALE);
-	}
+	return ((fixed_t) n) * FIXED_SCALE;
+}
 
-	fixed_t 
-	fixed_divide (fixed_t x, fixed_t y) {
-		return (fixed_t) ((((int64_t) x) * FIXED_SCALE) / y);
-	}
+fixed_t 
+fixed_multiply (fixed_t x, fixed_t y) {
+	return (fixed_t) (((int64_t) x) * y / FIXED_SCALE);
+}
 
-	int 
-	fixed_to_int_zero (fixed_t x) {
-		return x / FIXED_SCALE;
+fixed_t 
+fixed_divide (fixed_t x, fixed_t y) {
+	return (fixed_t) ((((int64_t) x) * FIXED_SCALE) / y);
+}
+
+int 
+fixed_to_int_zero (fixed_t x) {
+	return x / FIXED_SCALE;
+}
+int fixed_to_int_nearest (fixed_t x) {
+	if (x >= 0) {
+		return (x + FIXED_SCALE  / 2) / FIXED_SCALE;
+	} else {
+		return (x - FIXED_SCALE  / 2) / FIXED_SCALE;
 	}
-	int fixed_to_int_nearest (fixed_t x) {
-		if (x >= 0) {
-			return (x + FIXED_SCALE  / 2) / FIXED_SCALE;
-		} else {
-			return (x - FIXED_SCALE  / 2) / FIXED_SCALE;
-		}
-	}
-#endif
+}

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -296,7 +296,7 @@ thread_unblock (struct thread *t) {
 	if (thread_mlfqs)
 	{
 		//mlfq[priority]에 삽입
-		list_mlfqs_insert (&mlfq, &t->elem, t->priority, NULL);
+		list_mlfqs_insert (mlfq, &t->elem, t->priority, NULL);
 	}
 	else
 	{
@@ -369,7 +369,7 @@ thread_yield (void) {
 		if (thread_mlfqs)
 		{
 			//mlfq[priority]에 삽입
-			list_mlfqs_insert (&mlfq, &curr->elem, curr->priority, NULL);
+			list_mlfqs_insert (mlfq, &curr->elem, curr->priority, NULL);
 		}
 
 		else
@@ -438,11 +438,14 @@ thread_set_nice (int nice) {
 
 	//thread_set_priority를 사용할 수 없기에 수정
 	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry (list_begin(high_Q(mlfq)), struct thread, elem);
-	if(thread_begin->priority > new_priority)
-	{
+	struct list *list_be = high_Q(mlfq);
+	if(!list_empty(list_be)){
+		struct thread* thread_begin = list_entry (list_begin(list_be), struct thread, elem);
+		if(thread_begin->priority > new_priority)
+		{
 
-		thread_yield ();
+			thread_yield ();
+		}
 	}
 
 }
@@ -765,7 +768,7 @@ thread_wakeup () {
 		{
 			if(t->priority > thread_current()->priority)
 			{
-				thread_yield();
+				intr_yield_on_return();
 			}
 		}
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -79,7 +79,9 @@ fixed_t fixed_multiply (fixed_t,fixed_t);
 fixed_t fixed_divide (fixed_t,fixed_t);
 int fixed_to_int_zero (fixed_t);
 int fixed_to_int_nearest (fixed_t);
-
+//load_avg, ready_threads 선언
+static fixed_t load_avg;
+static int ready_threads;
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
 
@@ -339,8 +341,8 @@ thread_yield (void) {
 void
 thread_set_priority (int new_priority) {
 	thread_current ()->priority = new_priority;
-	struct thread* thread_temp = list_entry(list_begin(&ready_list),struct thread,elem);
-	if(thread_temp->priority>new_priority)
+	struct thread* thread_begin = list_entry(list_begin(&ready_list),struct thread,elem);
+	if(thread_begin->priority>new_priority)
 	{
 		thread_yield();
 	}
@@ -354,15 +356,35 @@ thread_get_priority (void) {
 
 /* Sets the current thread's nice value to NICE. */
 void
-thread_set_nice (int nice UNUSED) {
+thread_set_nice (int nice) {
 	/* TODO: Your implementation goes here */
+
+	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
+	struct thread* thread_curr = thread_current ();
+	thread_curr ->nice = nice;
+
+	//new_priority=PRI_MAX-recent_cpu/4-nice*2
+	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
+	new_priority = fixed_to_int_zero (new_priority);
+
+	if(new_priority > 63)
+	{
+		new_priority = 63;
+	}
+	if(new_priority < 0)
+	{
+		new_priority = 0;
+	}
+
+	thread_set_priority(new_priority);
+
 }
 
 /* Returns the current thread's nice value. */
 int
 thread_get_nice (void) {
 	/* TODO: Your implementation goes here */
-	return 0;
+	return thread_current () -> nice;
 }
 
 /* Returns 100 times the system load average. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -121,7 +121,8 @@ thread_init (void) {
 	list_init (&ready_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
-
+	//스레드 개수와 load_avg의 값을 0으로 초기화
+	ready_threads = load_avg = 0;
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
@@ -434,6 +435,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
+	//스레드의 기본 nice=0, recent_cpu=0;
+	t->nice = t->recent_cpu = 0;
+	
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -175,6 +175,10 @@ thread_tick (void) {
 #endif
 	else
 		kernel_ticks++;
+		
+	if (t != idle_thread && thread_mlfqs == true) {
+		t->recent_cpu += fixed_convert (1);
+	}
 
 	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -290,7 +290,16 @@ thread_unblock (struct thread *t) {
 	ASSERT (t->status == THREAD_BLOCKED);
 	//list_push_back (&ready_list, &t->elem);
 	void *aux=NULL;
-	list_insert_ordered(&ready_list, &t->elem,priority_isless,aux);
+
+	if (thread_mlfqs)
+	{
+		//mlfq[priority]에 삽입
+		list_mlfqs_insert (&mlfq, &t->elem, t->priority, NULL);
+	}
+	else
+	{
+		list_insert_ordered(&ready_list, &t->elem, priority_isless, aux);
+	}
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -352,10 +361,21 @@ thread_yield (void) {
 	ASSERT (!intr_context ());
 
 	old_level = intr_disable ();
-	if (curr != idle_thread){
-		//list_push_back (&ready_list, &curr->elem);
-		void *aux=NULL;
-		list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+	if (curr != idle_thread)
+	{
+
+		if (thread_mlfqs)
+		{
+			//mlfq[priority]에 삽입
+			list_mlfqs_insert (&mlfq, &curr->elem, curr->priority, NULL);
+		}
+
+		else
+		{
+			void *aux=NULL;
+			list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+		}
+
 	}
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
@@ -717,6 +737,15 @@ thread_wakeup () {
 		list_pop_front (&sleep_list);
 
 		thread_unblock (t);
+
+		if (thread_mlfqs)
+		{
+			if(t->priority > thread_current()->priority)
+			{
+				thread_yield();
+			}
+		}
+
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -131,25 +131,21 @@ thread_init (void) {
 
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
-	if (!thread_mlfqs)
-	{
-		list_init (&ready_list);
-	}
+	list_init (&ready_list);
 	list_init (&all_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
 	
 
-	if (thread_mlfqs)
+
+	//mlfq 초기화
+	for (int i=0 ; i <= PRI_MAX ; i++)
 	{
-		//mlfq 초기화
-		for (int i=0 ; i <= PRI_MAX ; i++)
-		{
-			list_init(&mlfq[i]);
-		}
-		//스레드 개수와 load_avg의 값을 0으로 초기화
-		ready_threads = load_avg = 0;
+		list_init(&mlfq[i]);
 	}
+	//스레드 개수와 load_avg의 값을 0으로 초기화
+	ready_threads = load_avg = 0;
+
 
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
@@ -198,13 +194,13 @@ thread_tick (void) {
 	if (++thread_ticks >= TIME_SLICE)
 	{
 		intr_yield_on_return ();
-		if(thread_mlfqs)
-		{
-			enum intr_level old_level;
-			old_level = intr_disable ();
-			priority_all_update(mlfq);
-			intr_set_level (old_level);
-		}
+	}
+	if(thread_mlfqs && thread_ticks % TIME_SLICE == 0)
+	{
+		enum intr_level old_level;
+		old_level = intr_disable ();
+		priority_all_update(mlfq);
+		intr_set_level (old_level);
 	}
 }
 
@@ -363,7 +359,10 @@ thread_exit (void) {
 	/* Just set our status to dying and schedule another process.
 	   We will be destroyed during the call to schedule_tail(). */
 	intr_disable ();
-	list_remove(&(thread_current ()->all_elem));
+	struct thread* cur = thread_current ();
+	ASSERT (cur->all_elem.prev != NULL);
+	ASSERT (cur->all_elem.next != NULL);
+	list_remove(&(cur->all_elem));
 	do_schedule (THREAD_DYING);
 	NOT_REACHED ();
 }
@@ -546,8 +545,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
 	
-	if (thread_mlfqs)
-	{
+
 	//스레드의 기본 nice=0, recent_cpu=0;
 	t->nice = t->recent_cpu = 0;
 
@@ -556,10 +554,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	list_push_back(&all_list, &(t->all_elem));
 
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
-	
-	
 
-	}
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -573,7 +568,7 @@ next_thread_to_run (void) {
 	{
 		struct list *high_list = high_Q(mlfq);
 		if (list_empty (high_list))
-		return idle_thread;
+			return idle_thread;
 	else
 		return list_entry (list_pop_front (high_list), struct thread, elem);
 	}
@@ -863,8 +858,10 @@ mlfqs_update_all_per_sec(void) {
 	
 	ready_threads = 0;
 	struct thread* t;
+	struct list_elem *a;
 
-	for (t = list_begin(&all_list); t != list_end(&all_list); t = list_next(t)) {
+	for (a = list_begin (&all_list); a != list_end (&all_list); a = list_next (a)) {
+		t = list_entry (a, struct thread, all_elem);
 		if (t == idle_thread) {
 			continue;
 		}
@@ -884,9 +881,10 @@ mlfqs_update_all_per_sec(void) {
 	
 	fixed_t coefficient = fixed_divide(fixed_multiply(fixed_convert(2), load_avg), (fixed_multiply(fixed_convert(2), load_avg) + fixed_convert(1)));
 	
-	for (t = list_begin(&all_list); t != list_end(&all_list); t = list_next(t)) {
+	for (a = list_begin (&all_list); a != list_end (&all_list); a = list_next (a)) {
+		t = list_entry (a, struct thread, all_elem);
 		if (t != idle_thread) {
-			t->recent_cpu = fixed_multiply(coefficient, t->recent_cpu) + fixed_convert(t->nice);	
+			t->recent_cpu = fixed_multiply (coefficient, t->recent_cpu) + fixed_convert (t->nice);	
 		}
 	}
 	intr_set_level (old_level);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -37,6 +37,8 @@ static bool priority_isless(const struct list_elem* a ,const struct list_elem* b
 }
 static struct list sleep_list;
 
+
+
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -62,6 +64,9 @@ static unsigned thread_ticks;   /* # of timer ticks since last yield. */
    If true, use multi-level feedback queue scheduler.
    Controlled by kernel command-line option "-o mlfqs". */
 bool thread_mlfqs;
+
+static int ready_threads;			/* ready list에 있는 thread 개수 */
+static fixed_t load_avg;			/* ready list에 있는 thread 개수가 클수록 큰 값을 가짐*/
 
 static void kernel_thread (thread_func *, void *aux);
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -132,7 +132,10 @@ thread_init (void) {
 
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
-	list_init (&ready_list);
+	if (!thread_mlfqs)
+	{
+		list_init (&ready_list);
+	}
 	list_init (&sleep_list);
 	list_init (&destruction_req);
 	
@@ -144,7 +147,6 @@ thread_init (void) {
 		{
 			list_init(&mlfq[i]);
 		}
-
 		//스레드 개수와 load_avg의 값을 0으로 초기화
 		ready_threads = load_avg = 0;
 	}
@@ -288,7 +290,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	//list_push_back (&ready_list, &t->elem);
+
 	void *aux=NULL;
 
 	if (thread_mlfqs)
@@ -399,18 +401,14 @@ thread_set_priority (int new_priority) {
 /* Returns the current thread's priority. */
 int
 thread_get_priority (void) {
-	return thread_current ()->priority;
-}
 
-/* Sets the current thread's nice value to NICE. */
-void
-thread_set_nice (int nice) {
+	//thread_mlfqs 아니면
+	if (!thread_mlfqs)
+	{
+		return thread_current ()->priority;
+	}
 
-	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
 	struct thread* thread_curr = thread_current ();
-	thread_curr ->nice = nice;
-
-	//new_priority=PRI_MAX-recent_cpu/4-nice*2
 	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
 	new_priority = fixed_to_int_zero (new_priority);
 
@@ -422,13 +420,29 @@ thread_set_nice (int nice) {
 	{
 		new_priority = 0;
 	}
+	
+	return new_priority;
+
+}
+
+/* Sets the current thread's nice value to NICE. */
+void
+thread_set_nice (int nice) {
+
+	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
+	struct thread* thread_curr = thread_current ();
+	thread_curr ->nice = nice;
+
+	//new_priority=PRI_MAX-recent_cpu/4-nice*2
+	int new_priority = thread_get_priority ();
 
 	//thread_set_priority를 사용할 수 없기에 수정
 	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+	struct thread* thread_begin = list_entry (list_begin(high_Q(mlfq)), struct thread, elem);
 	if(thread_begin->priority > new_priority)
 	{
-		thread_yield();
+
+		thread_yield ();
 	}
 
 }
@@ -531,10 +545,19 @@ init_thread (struct thread *t, const char *name, int priority) {
    idle_thread. */
 static struct thread *
 next_thread_to_run (void) {
+	if (thread_mlfqs)
+	{
+		struct list *high_list = high_Q(mlfq);
+		if (list_empty (high_list))
+		return idle_thread;
+	else
+		return list_entry (list_pop_front (high_list), struct thread, elem);
+	}
 	if (list_empty (&ready_list))
 		return idle_thread;
 	else
 		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+	
 }
 
 /* Use iretq to launch the thread */
@@ -749,6 +772,22 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
+
+struct list*
+high_Q(struct list* mlfqs)
+{
+	for(int i = PRI_MAX; i >=PRI_MIN ; i++)
+	{
+		if(!list_empty(&mlfqs[i]))
+		{
+			//우선 순위 위부터 탐색
+			return &mlfqs[i];
+		}
+	}
+	return &mlfqs[PRI_MAX];
+
+}
+
 
 fixed_t 
 fixed_convert (int n) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -29,13 +29,15 @@
 static struct list ready_list;
 static bool priority_isless(const struct list_elem* a ,const struct list_elem* b,void* aux)
 {
-	struct thread* thread_a = list_entry(a,struct thread,elem);
-	struct thread* thread_b = list_entry(b,struct thread,elem);
+	struct thread* thread_a = list_entry(a, struct thread, elem);
+	struct thread* thread_b = list_entry(b, struct thread, elem);
 
 
-	return thread_a->priority>thread_b->priority;
+	return thread_a->priority > thread_b->priority;
 }
 static struct list sleep_list;
+
+static struct list mlfq[64];
 
 
 
@@ -133,8 +135,20 @@ thread_init (void) {
 	list_init (&ready_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
-	//스레드 개수와 load_avg의 값을 0으로 초기화
-	ready_threads = load_avg = 0;
+	
+
+	if (thread_mlfqs)
+	{
+		//mlfq 초기화
+		for (int i=0 ; i <= PRI_MAX ; i++)
+		{
+			list_init(&mlfq[i]);
+		}
+
+		//스레드 개수와 load_avg의 값을 0으로 초기화
+		ready_threads = load_avg = 0;
+	}
+
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
@@ -215,6 +229,12 @@ thread_create (const char *name, int priority,
 		return TID_ERROR;
 
 	/* Initialize thread. */
+
+	if (thread_mlfqs)
+	{
+		//mlfqs 모드에서는 새로 생성된 스레드의 우선도가 최상위
+		priority=PRI_MAX;
+	}
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
@@ -344,6 +364,10 @@ thread_yield (void) {
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
+	if (thread_mlfqs)
+	{
+		return ;
+	}
 	thread_current ()->priority = new_priority;
 	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
 	if(thread_begin->priority > new_priority)
@@ -463,9 +487,15 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
+	
+	if (thread_mlfqs)
+	{
 	//스레드의 기본 nice=0, recent_cpu=0;
 	t->nice = t->recent_cpu = 0;
 	
+	
+
+	}
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -375,15 +375,13 @@ thread_get_nice (void) {
 /* Returns 100 times the system load average. */
 int
 thread_get_load_avg (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+	return fixed_to_int_nearest((load_avg) * 100);
 }
 
 /* Returns 100 times the current thread's recent_cpu value. */
 int
 thread_get_recent_cpu (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+	return fixed_to_int_nearest((thread_current ()->recent_cpu) * 100);
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.
@@ -669,7 +667,6 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
-
 
 fixed_t 
 fixed_convert (int n) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -403,7 +403,13 @@ thread_set_nice (int nice) {
 		new_priority = 0;
 	}
 
-	thread_set_priority(new_priority);
+	//thread_set_priority를 사용할 수 없기에 수정
+	thread_current ()->priority = new_priority;
+	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+	if(thread_begin->priority > new_priority)
+	{
+		thread_yield();
+	}
 
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -36,6 +36,7 @@ static bool priority_isless(const struct list_elem* a ,const struct list_elem* b
 	return thread_a->priority>thread_b->priority;
 }
 static struct list sleep_list;
+static struct list all_list;
 
 
 
@@ -131,6 +132,7 @@ thread_init (void) {
 
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
+	list_init (&all_list);
 	list_init (&ready_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
@@ -319,6 +321,7 @@ thread_exit (void) {
 	/* Just set our status to dying and schedule another process.
 	   We will be destroyed during the call to schedule_tail(). */
 	intr_disable ();
+	list_remove(&(thread_current ()->all_elem));
 	do_schedule (THREAD_DYING);
 	NOT_REACHED ();
 }
@@ -448,6 +451,12 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 	//스레드의 기본 nice=0, recent_cpu=0;
 	t->nice = t->recent_cpu = 0;
+
+	enum intr_level old_level = intr_disable ();	/* interrupt 방해금지모드 설정 */
+
+	list_push_back(&all_list, &(t->all_elem));
+
+	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 	
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -79,9 +79,6 @@ fixed_t fixed_multiply (fixed_t,fixed_t);
 fixed_t fixed_divide (fixed_t,fixed_t);
 int fixed_to_int_zero (fixed_t);
 int fixed_to_int_nearest (fixed_t);
-//load_avg, ready_threads 선언
-static fixed_t load_avg;
-static int ready_threads;
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -29,15 +29,16 @@
 static struct list ready_list;
 static bool priority_isless(const struct list_elem* a ,const struct list_elem* b,void* aux)
 {
-	struct thread* thread_a = list_entry(a,struct thread,elem);
-	struct thread* thread_b = list_entry(b,struct thread,elem);
+	struct thread* thread_a = list_entry(a, struct thread, elem);
+	struct thread* thread_b = list_entry(b, struct thread, elem);
 
 
-	return thread_a->priority>thread_b->priority;
+	return thread_a->priority > thread_b->priority;
 }
 static struct list sleep_list;
+static struct list all_list;
 
-
+static struct list mlfq[64];
 
 /* Idle thread. */
 static struct thread *idle_thread;
@@ -78,7 +79,6 @@ static void schedule (void);
 static tid_t allocate_tid (void);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
-
 
 /* MLFQS에서 사용하는 Fixed Point 연산을 위한 helper functions */
 fixed_t fixed_convert (int);
@@ -131,8 +131,15 @@ thread_init (void) {
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
 	list_init (&ready_list);
+	list_init (&all_list);
 	list_init (&sleep_list);
 	list_init (&destruction_req);
+
+	//mlfq 초기화
+	for (int i=0 ; i <= PRI_MAX ; i++)
+	{
+		list_init(&mlfq[i]);
+	}
 	//스레드 개수와 load_avg의 값을 0으로 초기화
 	ready_threads = load_avg = 0;
 	/* Set up a thread structure for the running thread. */
@@ -173,11 +180,26 @@ thread_tick (void) {
 #endif
 	else
 		kernel_ticks++;
+		
+	if (t != idle_thread && thread_mlfqs == true) {
+		t->recent_cpu += fixed_convert (1);
+	}
 
 	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)
+	{
 		intr_yield_on_return ();
+	}
+	int64_t cur_ticks = timer_ticks ();
+	if(thread_mlfqs && cur_ticks % TIME_SLICE == 0)
+	{
+		enum intr_level old_level;
+		old_level = intr_disable ();
+		priority_all_update(mlfq);
+		intr_set_level (old_level);
+	}
 }
+
 
 /* Prints thread statistics. */
 void
@@ -215,6 +237,12 @@ thread_create (const char *name, int priority,
 		return TID_ERROR;
 
 	/* Initialize thread. */
+
+	if (thread_mlfqs)
+	{
+		//mlfqs 모드에서는 새로 생성된 스레드의 우선도가 최상위
+		priority=PRI_MAX;
+	}
 	init_thread (t, name, priority);
 	tid = t->tid = allocate_tid ();
 
@@ -228,7 +256,14 @@ thread_create (const char *name, int priority,
 	t->tf.ss = SEL_KDSEG;
 	t->tf.cs = SEL_KCSEG;
 	t->tf.eflags = FLAG_IF;
-
+	if (thread_mlfqs)
+  		t->nice = thread_current()->nice;
+	else
+  		t->nice = 0;
+	if (thread_mlfqs)
+  		t->recent_cpu = thread_current()->recent_cpu;
+	else	
+		t->recent_cpu = 0;
 	/* Add to run queue. */
 	thread_unblock (t);
 	if(priority > thread_current()->priority)
@@ -268,9 +303,18 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	//list_push_back (&ready_list, &t->elem);
+
 	void *aux=NULL;
-	list_insert_ordered(&ready_list, &t->elem,priority_isless,aux);
+
+	if (thread_mlfqs)
+	{
+		//mlfq[priority]에 삽입
+		list_mlfqs_insert (mlfq, &t->elem, t->priority, NULL);
+	}
+	else
+	{
+		list_insert_ordered(&ready_list, &t->elem, priority_isless, aux);
+	}
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -318,6 +362,10 @@ thread_exit (void) {
 	/* Just set our status to dying and schedule another process.
 	   We will be destroyed during the call to schedule_tail(). */
 	intr_disable ();
+	struct thread* cur = thread_current ();
+	ASSERT (cur->all_elem.prev != NULL);
+	ASSERT (cur->all_elem.next != NULL);
+	list_remove(&(cur->all_elem));
 	do_schedule (THREAD_DYING);
 	NOT_REACHED ();
 }
@@ -332,10 +380,21 @@ thread_yield (void) {
 	ASSERT (!intr_context ());
 
 	old_level = intr_disable ();
-	if (curr != idle_thread){
-		//list_push_back (&ready_list, &curr->elem);
-		void *aux=NULL;
-		list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+	if (curr != idle_thread)
+	{
+
+		if (thread_mlfqs)
+		{
+			//mlfq[priority]에 삽입
+			list_mlfqs_insert (mlfq, &curr->elem, curr->priority, NULL);
+		}
+
+		else
+		{
+			void *aux=NULL;
+			list_insert_ordered(&ready_list, &curr->elem,priority_isless,aux);
+		}
+
 	}
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
@@ -344,18 +403,48 @@ thread_yield (void) {
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
-	if(thread_begin->priority > new_priority)
+	if (thread_mlfqs)
 	{
-		thread_yield();
+		return ;
+	}
+
+	thread_current ()->priority = new_priority;
+	
+	if(!list_empty(&ready_list))
+	{
+		struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+		if(thread_begin->priority > new_priority)
+		{
+			thread_yield();
+		}
 	}
 }
 
 /* Returns the current thread's priority. */
 int
 thread_get_priority (void) {
-	return thread_current ()->priority;
+
+	//thread_mlfqs 아니면
+	if (!thread_mlfqs)
+	{
+		return thread_current ()->priority;
+	}
+
+	struct thread* thread_curr = thread_current ();
+	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
+	new_priority = fixed_to_int_zero (new_priority);
+
+	if(new_priority > PRI_MAX)
+	{
+		new_priority = PRI_MAX;
+	}
+	if(new_priority < PRI_MIN)
+	{
+		new_priority = PRI_MIN;
+	}
+	
+	return new_priority;
+
 }
 
 /* Sets the current thread's nice value to NICE. */
@@ -367,19 +456,19 @@ thread_set_nice (int nice) {
 	thread_curr ->nice = nice;
 
 	//new_priority=PRI_MAX-recent_cpu/4-nice*2
-	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
-	new_priority = fixed_to_int_zero (new_priority);
+	int new_priority = thread_get_priority ();
 
-	if(new_priority > 63)
-	{
-		new_priority = 63;
-	}
-	if(new_priority < 0)
-	{
-		new_priority = 0;
-	}
+	//thread_set_priority를 사용할 수 없기에 수정
+	thread_current ()->priority = new_priority;
+	struct list *list_be = high_Q(mlfq);
+	if(!list_empty(list_be)){
+		struct thread* thread_begin = list_entry (list_begin(list_be), struct thread, elem);
+		if(thread_begin->priority > new_priority)
+		{
 
-	thread_set_priority(new_priority);
+			thread_yield ();
+		}
+	}
 
 }
 
@@ -463,9 +552,17 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
-	//스레드의 기본 nice=0, recent_cpu=0;
-	t->nice = t->recent_cpu = 0;
 	
+
+  		t->nice = 0;
+		t->recent_cpu = 0;
+
+	enum intr_level old_level = intr_disable ();	/* interrupt 방해금지모드 설정 */
+
+	list_push_back(&all_list, &(t->all_elem));
+
+	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
+
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -475,10 +572,19 @@ init_thread (struct thread *t, const char *name, int priority) {
    idle_thread. */
 static struct thread *
 next_thread_to_run (void) {
+	if (thread_mlfqs)
+	{
+		struct list *high_list = high_Q(mlfq);
+		if (list_empty (high_list))
+			return idle_thread;
+	else
+		return list_entry (list_pop_front (high_list), struct thread, elem);
+	}
 	if (list_empty (&ready_list))
 		return idle_thread;
 	else
 		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+	
 }
 
 /* Use iretq to launch the thread */
@@ -681,9 +787,124 @@ thread_wakeup () {
 		list_pop_front (&sleep_list);
 
 		thread_unblock (t);
+
+		if (thread_mlfqs)
+		{
+			if(t->priority > thread_current()->priority)
+			{
+				intr_yield_on_return();
+			}
+		}
+
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
+void priority_all_update(struct list mlfqs[64]){
+
+	struct thread* t;
+	struct list_elem *a;
+	//all_list를 돌면서 ready, running의 priority 재 검사후 각각 갱신
+	for (a = list_begin (&all_list); a != list_end (&all_list); a = list_next (a)) {
+		t = list_entry (a, struct thread, all_elem);
+		if (t == idle_thread) {
+			continue;
+		}
+		if (t->status == THREAD_READY || t->status == THREAD_RUNNING) {
+			int new_priority = fixed_convert (PRI_MAX) - t->recent_cpu/4 - fixed_convert (t->nice) * 2;
+			new_priority = fixed_to_int_zero (new_priority);
+
+			if(new_priority > PRI_MAX)
+			{
+				new_priority = PRI_MAX;
+			}
+
+			if(new_priority < PRI_MIN)
+			{
+				new_priority = PRI_MIN;
+			}
+			if(t->priority!=new_priority && t->status == THREAD_READY)
+			{
+				list_remove(&t->elem);
+				list_push_back(&mlfqs[new_priority], &t->elem);
+				t->priority=new_priority;
+				if(new_priority > thread_get_priority())
+				{
+					intr_yield_on_return();
+				}
+			}
+			if(t->status == THREAD_RUNNING)
+			{
+				thread_current ()->priority = new_priority;
+				struct list *list_be = high_Q(mlfq);
+				if(!list_empty(list_be)){
+					struct thread* thread_begin = list_entry (list_begin(list_be), struct thread, elem);
+					if(thread_begin->priority > new_priority)
+					{
+						intr_yield_on_return();
+					}
+				}
+			}
+		}
+
+	}
+}
+
+
+struct list*
+high_Q(struct list* mlfqs)
+{
+	for(int i = PRI_MAX; i >=PRI_MIN ; i--)
+	{
+		if(!list_empty(&mlfqs[i]))
+		{
+			//우선 순위 위부터 탐색
+			return &mlfqs[i];
+		}
+	}
+	return &mlfqs[PRI_MAX];
+
+}
+
+void 
+mlfqs_update_all_per_sec(void) {
+	enum intr_level old_level;
+	old_level = intr_disable ();
+	
+	ready_threads = 0;
+	struct thread* t;
+	struct list_elem *a;
+
+	for (a = list_begin (&all_list); a != list_end (&all_list); a = list_next (a)) {
+		t = list_entry (a, struct thread, all_elem);
+		if (t == idle_thread) {
+			continue;
+		}
+		if (t->status == THREAD_RUNNING || t->status == THREAD_READY) {
+			ready_threads ++;
+		}
+	}
+
+	/*
+
+	load_avg = (59 / 60) * load_avg + (1 / 60) * ready_threads;
+	recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * recent_cpu + nice;
+
+	 */
+	load_avg = fixed_multiply(fixed_divide(fixed_convert(59), fixed_convert(60)), load_avg) 
+				+ fixed_multiply(fixed_divide(fixed_convert(1), fixed_convert(60)), fixed_convert(ready_threads));
+	
+	fixed_t coefficient = fixed_divide(fixed_multiply(fixed_convert(2), load_avg), (fixed_multiply(fixed_convert(2), load_avg) + fixed_convert(1)));
+	
+	for (a = list_begin (&all_list); a != list_end (&all_list); a = list_next (a)) {
+		t = list_entry (a, struct thread, all_elem);
+		if (t != idle_thread) {
+			t->recent_cpu = fixed_multiply (coefficient, t->recent_cpu) + fixed_convert (t->nice);	
+		}
+	}
+	intr_set_level (old_level);
+}
+
+
 
 fixed_t 
 fixed_convert (int n) {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -39,8 +39,6 @@ static struct list sleep_list;
 
 static struct list mlfq[64];
 
-
-
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -80,7 +78,7 @@ static void schedule (void);
 static tid_t allocate_tid (void);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
-
+static struct list temp_mlfqs[64];
 
 /* MLFQS에서 사용하는 Fixed Point 연산을 위한 helper functions */
 fixed_t fixed_convert (int);
@@ -192,8 +190,18 @@ thread_tick (void) {
 
 	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)
+	{
 		intr_yield_on_return ();
+		if(thread_mlfqs)
+		{
+			enum intr_level old_level;
+			old_level = intr_disable ();
+			priority_all_update(mlfq);
+			intr_set_level (old_level);
+		}
+	}
 }
+
 
 /* Prints thread statistics. */
 void
@@ -412,13 +420,13 @@ thread_get_priority (void) {
 	int new_priority = fixed_convert (PRI_MAX) - thread_curr->recent_cpu/4 - fixed_convert (thread_curr->nice) * 2;
 	new_priority = fixed_to_int_zero (new_priority);
 
-	if(new_priority > 63)
+	if(new_priority > PRI_MAX)
 	{
-		new_priority = 63;
+		new_priority = PRI_MAX;
 	}
-	if(new_priority < 0)
+	if(new_priority < PRI_MIN)
 	{
-		new_priority = 0;
+		new_priority = PRI_MIN;
 	}
 	
 	return new_priority;
@@ -775,11 +783,55 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
+void priority_all_update(struct list mlfqs[64]){
+
+
+	for(int i = 0 ; i <= PRI_MAX ; i++)
+	{
+		list_init(&temp_mlfqs[i]);
+	}
+
+	for(int i = 0 ; i <= PRI_MAX ; i++){
+
+		struct list_elem *e;
+		while (!list_empty(&mlfqs[i]))
+		{
+			e=list_pop_front(&mlfqs[i]);
+			struct thread *nowthread = list_entry(e, struct thread, elem);
+			int new_priority = fixed_convert (PRI_MAX) - nowthread->recent_cpu/4 - fixed_convert (nowthread->nice) * 2;
+			new_priority = fixed_to_int_zero (new_priority);
+
+			if(new_priority > PRI_MAX)
+			{
+				new_priority = PRI_MAX;
+			}
+
+			if(new_priority < PRI_MIN)
+			{
+				new_priority = PRI_MIN;
+			}
+			if(nowthread->priority!=new_priority)
+			{
+				nowthread->priority=new_priority;
+			}
+			list_push_back (&temp_mlfqs[new_priority], e);
+		}
+	}
+	for(int i = 0 ; i <= PRI_MAX ; i++)
+	{
+    	while (!list_empty(&temp_mlfqs[i]))
+		{
+			struct list_elem *e = list_pop_front(&temp_mlfqs[i]);
+			list_push_back(&mlfqs[i], e);
+		}
+	}
+}
+
 
 struct list*
 high_Q(struct list* mlfqs)
 {
-	for(int i = PRI_MAX; i >=PRI_MIN ; i++)
+	for(int i = PRI_MAX; i >=PRI_MIN ; i--)
 	{
 		if(!list_empty(&mlfqs[i]))
 		{

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -338,8 +338,8 @@ thread_yield (void) {
 void
 thread_set_priority (int new_priority) {
 	thread_current ()->priority = new_priority;
-	struct thread* thread_begin = list_entry(list_begin(&ready_list),struct thread,elem);
-	if(thread_begin->priority>new_priority)
+	struct thread* thread_begin = list_entry (list_begin(&ready_list), struct thread, elem);
+	if(thread_begin->priority > new_priority)
 	{
 		thread_yield();
 	}
@@ -354,7 +354,6 @@ thread_get_priority (void) {
 /* Sets the current thread's nice value to NICE. */
 void
 thread_set_nice (int nice) {
-	/* TODO: Your implementation goes here */
 
 	//현재 스레드를 thread_curr에 저장 - 함수명과 구분
 	struct thread* thread_curr = thread_current ();
@@ -380,7 +379,6 @@ thread_set_nice (int nice) {
 /* Returns the current thread's nice value. */
 int
 thread_get_nice (void) {
-	/* TODO: Your implementation goes here */
 	return thread_current () -> nice;
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -74,6 +74,8 @@ static tid_t allocate_tid (void);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
 
+
+/* MLFQS에서 사용하는 Fixed Point 연산을 위한 helper functions */
 fixed_t fixed_convert (int);
 fixed_t fixed_multiply (fixed_t,fixed_t);
 fixed_t fixed_divide (fixed_t,fixed_t);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -375,13 +375,13 @@ thread_get_nice (void) {
 /* Returns 100 times the system load average. */
 int
 thread_get_load_avg (void) {
-	return fixed_to_int_nearest((load_avg) * 100);
+	return fixed_to_int_nearest(load_avg * 100);
 }
 
 /* Returns 100 times the current thread's recent_cpu value. */
 int
 thread_get_recent_cpu (void) {
-	return fixed_to_int_nearest((thread_current ()->recent_cpu) * 100);
+	return fixed_to_int_nearest(thread_current ()->recent_cpu * 100);
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -1,3 +1,5 @@
+#define MLFQS
+
 #include "threads/thread.h"
 #include <debug.h>
 #include <stddef.h>
@@ -73,6 +75,14 @@ static void schedule (void);
 static tid_t allocate_tid (void);
 void thread_sleep (int64_t ticks);
 void thread_wakeup (void);
+
+#ifdef MLFQS
+	fixed_t fixed_convert (int);
+	fixed_t fixed_multiply (fixed_t,fixed_t);
+	fixed_t fixed_divide (fixed_t,fixed_t);
+	int fixed_to_int_zero (fixed_t);
+	int fixed_to_int_nearest (fixed_t);
+#endif
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -652,3 +662,33 @@ thread_wakeup () {
 	}	
 	intr_set_level (old_level);						/* interrupt 방해금지모드 해제 */
 }
+
+#ifdef MLFQS
+	fixed_t 
+	fixed_convert (int n) {
+
+		return ((fixed_t) n) * FIXED_SCALE;
+	}
+
+	fixed_t 
+	fixed_multiply (fixed_t x, fixed_t y) {
+		return (fixed_t) (((int64_t) x) * y / FIXED_SCALE);
+	}
+
+	fixed_t 
+	fixed_divide (fixed_t x, fixed_t y) {
+		return (fixed_t) ((((int64_t) x) * FIXED_SCALE) / y);
+	}
+
+	int 
+	fixed_to_int_zero (fixed_t x) {
+		return x / FIXED_SCALE;
+	}
+	int fixed_to_int_nearest (fixed_t x) {
+		if (x >= 0) {
+			return (x + FIXED_SCALE  / 2) / FIXED_SCALE;
+		} else {
+			return (x - FIXED_SCALE  / 2) / FIXED_SCALE;
+		}
+	}
+#endif


### PR DESCRIPTION
## 변경 사항

- MLFQS 모드에서 사용할 `nice`, `recent_cpu`, `load_avg` 값을 추가하고 조회/갱신 로직을 구현했습니다.
- 매 tick마다 실행 중인 thread의 `recent_cpu`를 증가시키도록 구현했습니다.
- 매 4 tick마다 MLFQS priority를 재계산하고 ready queue를 갱신하도록 구현했습니다.
- 매 1초마다 `load_avg`와 전체 thread의 `recent_cpu`를 재계산하도록 구현했습니다.
- MLFQS용 ready queue(`mlfq`)와 가장 높은 priority queue를 찾는 로직을 추가했습니다.
- 전체 thread를 순회하기 위한 `all_list`를 추가했습니다.
- MLFQS 모드에서는 `thread_set_priority()`가 직접 priority를 바꾸지 않도록 처리했습니다.

## 테스트 방법

1. `cd /workspaces/Jungle-pintos_22-04_lab/pintos/threads`
2. `make check`
3. MLFQS 관련 테스트가 통과하는지 확인했습니다.
4. `pintos/` 폴더 외 불필요한 변경이 포함되지 않았는지 확인했습니다.

## 리뷰어가 확인할 것

- [ ] MLFQS priority 계산식이 문서 요구사항과 일치하는가?
- [ ] `load_avg`와 `recent_cpu`가 올바른 tick 주기에 갱신되는가?
- [ ] `mlfq` ready queue에서 thread가 누락되거나 중복 삽입될 가능성이 없는가?
- [ ] `thread_set_nice()` 이후 priority 재계산과 yield 동작이 적절한가?
- [ ] 기존 priority scheduling / alarm / synchronization 동작에 회귀가 없는가?

## 관련 이슈

Closes #34 #28 #32 #35 #29 