### PR TITLE
feat: lock_acquire 함수에서 priority donation 기능 구현

### DIFF
--- a/docs/project1/donation.md
+++ b/docs/project1/donation.md
@@ -40,7 +40,6 @@ lock_acquire (struct lock *lock) {
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
-    donate_to_lock_holder(lock);
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
 }
@@ -53,7 +52,10 @@ sema_down (struct semaphore *sema) {
 	ASSERT (!intr_context ());
 
 	old_level = intr_disable ();
-	while (sema->value = 0) {
+    if (sema->value == 0) {
+        donate_to_lock_holder(lock);
+    }
+	while (sema->value == 0) {
 	    리스트에 순서 맞춰서 넣기 (&sema->waiters, &thread_current ()->wait_elem);
 		thread_block ();
 	
@@ -62,7 +64,7 @@ sema_down (struct semaphore *sema) {
 }
 
  
-newFunction donate_to_lock_holder (struct lock *lock) {
+void donate_to_lock_holder (struct lock *lock) {
     cur = thread_current ();
     cur ->waiting_lock = lock;
 

--- a/docs/project1/donation.md
+++ b/docs/project1/donation.md
@@ -40,6 +40,9 @@ lock_acquire (struct lock *lock) {
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
+    if (lock->holder != NULL) {
+        donate_to_lock_holder(lock);
+    }
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
 }
@@ -52,9 +55,6 @@ sema_down (struct semaphore *sema) {
 	ASSERT (!intr_context ());
 
 	old_level = intr_disable ();
-    if (sema->value == 0) {
-        donate_to_lock_holder(lock);
-    }
 	while (sema->value == 0) {
 	    리스트에 순서 맞춰서 넣기 (&sema->waiters, &thread_current ()->wait_elem);
 		thread_block ();

--- a/docs/project1/donation.md
+++ b/docs/project1/donation.md
@@ -40,7 +40,7 @@ lock_acquire (struct lock *lock) {
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
-    donation_to_lock_holder(lock);
+    donate_to_lock_holder(lock);
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
 }
@@ -62,7 +62,7 @@ sema_down (struct semaphore *sema) {
 }
 
  
-newFunction donation_to_lock_holder (struct lock *lock) {
+newFunction donate_to_lock_holder (struct lock *lock) {
     cur = thread_current ();
     cur ->waiting_lock = lock;
 

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -203,6 +203,16 @@ recalculate_priority (struct lock *lock) {
 	}        
 }
 
+void 
+donate_to_lock_holder (struct lock *lock) {
+    struct thread* cur = thread_current ();
+    cur->waiting_lock = lock;
+
+    list_insert_ordered (&lock->holder->donators, &cur->donator_elem, priority_more_func, NULL);
+
+    recalculate_priority (lock);
+}
+
 /* Acquires LOCK, sleeping until it becomes available if
    necessary.  The lock must not already be held by the current
    thread.

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -227,6 +227,9 @@ lock_acquire (struct lock *lock) {
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
+	if (lock->holder != NULL) {
+		donate_to_lock_holder (lock);
+	}
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
 }


### PR DESCRIPTION
## 변경 사항

- `sync.c`에 priority donation 기능을 수행할 수 있도록 `lock_acquire` 함수를 수정했습니다.
- 해당 함수에서 주어진 조건(lock holder가 존재할 경우(누군가 이미 락을 잡고 있을 경우))

## 테스트 방법

1. `docs/project1/donation.md` 파일을 엽니다.
2. 해당 파일에서 설계한 대로 구현했는지 확인합니다.
3. 구현에서 논리적 오류가 없는지 확인합니다.
4. <<`lock_acquire`함수에서 if (lockholder != NULL)을 확인하는 순간에는 NULL로 검사를 통과하자마자 context switch 가 일어나서 다른 스레드가 해당 락을 점유했다면 lock을 wait 하기는 하지만, donate 하지 않는 상황이 발생할 수 있지 않은지 검사해야 합니다. PR 생성자는 해당 논리적 결함이 실제할 것이라고 생각합니다. 함께 논의해봅시다. 바로 생각나는 해법은 이 작업을 할 때 intr_disable 등으로  인터럽트를 끄고 작업하는 방법이 있을 것 같습니다. >>

## 리뷰어가 확인할 것

- [ ] 오타가 없는가?
- [ ] 변경 범위가 `synch.c` 안으로 제한되어 있는가?
- [ ] `donate_to_lock_holder` 호출을 위해 lock holder 검사를 할 때 race condition이 발생하지 않는가?

## 관련 이슈

Closes #72 