### PR TITLE
Issue 74 donation lock release v2

### DIFF
--- a/docs/project1/donation_경근.md
+++ b/docs/project1/donation_경근.md
@@ -1,0 +1,22 @@
+struct thread:
+    waiting_lock 내가 지금 기다리는 lock
+    도네이터 리스트: 기부 받은 priority(아마 리스트 속의 리스트 형태?)
+    base_priority 원래 priority
+
+lock_acquire: 우리 테스트에서는 High_스레드(현재_스레드)가 lock을 얻으려고 함. 
+    1.lock holder가 없다면 sema_down 바로 실행. value가 1이어서 sema_down 바로 통과되고 lock 획득.(lock_init에서 일단 value 1로 설정해줌)
+    2.lock holder가 있고 || lock holder가 현재_스레드보다 우선순위가 작다면:
+        lock.holder의 donator 리스트에 푸쉬백
+        donator 리스트에서 list_sort 후 제일 앞에 있는 값으로 priority 설정
+        sema_down으로 lock 기다림
+    (lock_release로 깨어나서 lock을 얻고 난 후)
+    내 waiting_lock = NULL
+    lock->holder = 현재_스레드(나)
+
+lock_release: donation을 받은 현재_스레드가 들고 있던 lock을 내려놓고, 그 lock을 기다리던 스레드가 도전할 수 있게 하는 함수
+ㄴ> 우리 테스트에서는 현재_스레드가 Low임
+    현재_스레드의 donator가 있고 || 이 donator의 waiting_lock과 지금 release하는 lock이 같다면:
+        현재_스레드의 donator = NULL
+    현재_스레드의 원래 priority를 base_priority로 복구
+    lock->holder = NULL
+    sema_up으로 기다리던 High 스레드 깨움(대신 이때 정렬을 한 번 더 해야 됨. 근데 언제 깨어나는지 모르겠음)

--- a/docs/project1/donation_원재.md
+++ b/docs/project1/donation_원재.md
@@ -1,0 +1,68 @@
+priority 비교 함수
+a_thread = a에서 thread 꺼냄
+b_thread = b에서 thread 꺼냄
+
+a_thread의 max_p > b_thread의 max_p 이면 a가 먼저
+
+struct thread
+1. waiting_lock
+   내가 지금 기다리는 lock 하나
+2. donor
+   나에게 priority를 기부한 thread 하나
+   여러 명 저장 안 함
+3. max_p
+   실제로 스케줄링에 쓰는 priority
+4. base_p
+   원래 priority
+   thread_set_priority가 바꾸는 값
+
+max_p 계산
+
+나에게 donor가 없으면:
+  max_p = base_p
+나에게 donor가 있으면:
+  max_p = max(base_p, donor의 max_p)
+
+set_priority
+
+내 base_p를 새 priority로 바꿈
+내 max_p를 다시 계산
+내가 waiting_lock을 기다리는 중이면:
+  그 lock의 주인에게
+  내 max_p를 기준으로 donation 갱신 요청
+donation 갱신 함수
+
+입력:
+  donor = priority를 주는 thread
+  receiver = priority를 받는 thread
+receiver의 donor를 donor로 설정
+receiver의 이전 max_p 기억
+receiver의 max_p 다시 계산
+receiver의 max_p가 이전보다 커졌고,
+receiver도 어떤 lock을 기다리는 중이면:
+  receiver가 기다리는 lock의 주인에게
+  receiver를 donor로 해서 donation 갱신 요청
+
+lock_acquire
+
+lock 주인이 없으면:
+  그냥 lock 획득 시도
+lock 주인이 있으면:
+  내 waiting_lock = 이 lock
+  lock 주인에게 나를 donor로 donation 갱신 요청
+
+sema_down으로 lock 기다림
+
+깨어나서 lock을 얻으면:
+  내 waiting_lock = NULL
+  lock 주인 = 나
+
+lock_release
+
+내가 lock을 release함
+만약 내 donor가 있고,
+그 donor의 waiting_lock이 지금 release하는 lock이면:
+  내 donor = NULL
+내 max_p 다시 계산
+lock 주인 = NULL
+sema_up으로 다음 waiter 깨움

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -251,6 +251,7 @@ lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
+	return_donation_back_to_donator (lock);
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
 }
@@ -264,7 +265,7 @@ lock_held_by_current_thread (const struct lock *lock) {
 
 	return lock->holder == thread_current ();
 }
-
+
 /* One semaphore in a list. */
 struct semaphore_elem {
 	struct list_elem elem;              /* List element. */

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -203,6 +203,21 @@ recalculate_priority (struct lock *lock) {
 	}        
 }
 
+void remove_donate (struct lock *lock) { // lock->holder의 (donator_list를 비우고) priority를 재계산
+	struct thread* t = lock->holder;
+	struct list_elem* donator_elem = list_begin(&t->donators);
+    while(!list_empty(&t->donators)){
+		if(donator_elem == list_end(&t->donators)) break;
+		struct thread* donator = list_entry(donator_elem, struct thread, donator_elem);
+        if (donator->waiting_lock == lock){
+			list_remove(&donator->donator_elem);
+		}
+		donator_elem = donator_elem->next;
+	}
+    
+    recalculate_priority (lock);
+}
+
 /* Acquires LOCK, sleeping until it becomes available if
    necessary.  The lock must not already be held by the current
    thread.
@@ -251,7 +266,7 @@ lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
 
-	return_donation_back_to_donator (lock);
+	remove_donate (lock);
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -205,12 +205,12 @@ recalculate_priority (struct lock *lock) {
 
 void remove_donate (struct lock *lock) { // lock->holder의 (donator_list를 비우고) priority를 재계산
 	struct thread* t = lock->holder;
-	struct list_elem* donator_elem = list_begin(&t->donators);
-    while(!list_empty(&t->donators)){
-		if(donator_elem == list_end(&t->donators)) break;
-		struct thread* donator = list_entry(donator_elem, struct thread, donator_elem);
-        if (donator->waiting_lock == lock){
-			list_remove(&donator->donator_elem);
+	struct list_elem* donator_elem = list_begin (&t->donators);
+    while(!list_empty (&t->donators)) {
+		if (donator_elem == list_end(&t->donators)) break;
+		struct thread* donator = list_entry (donator_elem, struct thread, donator_elem);
+        if (donator->waiting_lock == lock) {
+			list_remove (&donator->donator_elem);
 		}
 		donator_elem = donator_elem->next;
 	}


### PR DESCRIPTION
## 작업 내용

- `lock_release()`에서 lock 해제 전 donation 제거 로직을 호출하도록 변경했습니다.
- `remove_donate()` 헬퍼 함수를 추가해 현재 lock과 관련된 donor만 제거하도록 구현했습니다.
- donation 제거 후 `recalculate_priority()`로 남은 donation 기준 priority를 다시 계산하도록 연결했습니다.
- Priority Donation 설계 문서를 추가했습니다.

## 테스트

- [ ] `priority-donate-one`
- [ ] `priority-donate-multiple`
- [ ] `priority-donate-multiple2`
- [ ] `priority-donate-lower`

## 참고

- 현재 브랜치는 Project 4 donation 중 `lock_release()` 시 donation 제거 흐름을 담당합니다.
- release하는 lock과 관련된 donation만 제거하고, 다른 lock으로 인한 donation은 유지하는 것을 목표로 합니다.

close #74 