### PR TITLE
feat: stdout write 시스템 콜 최소 연결

### DIFF
--- a/pintos/tests/userprog/Make.tests
+++ b/pintos/tests/userprog/Make.tests
@@ -143,3 +143,8 @@ tests/userprog/wait-killed_PUTFILES += tests/userprog/child-bad
 tests/userprog/rox-child_PUTFILES += tests/userprog/child-rox
 tests/userprog/rox-multichild_PUTFILES += tests/userprog/child-rox
 tests/userprog/exec-read_PUTFILES += tests/userprog/child-read
+
+# Local smoke test for syscall/stdout experiments.
+tests/userprog_PROGS += tests/userprog/printtest
+tests/userprog/printtest_SRC = tests/userprog/printtest.c tests/lib.c
+tests/userprog/printtest.output: TEST = tests/userprog/printtest

--- a/pintos/tests/userprog/printtest.c
+++ b/pintos/tests/userprog/printtest.c
@@ -1,0 +1,10 @@
+#include "tests/lib.h"
+
+
+int
+main (void) 
+{
+    test_name = "merong";
+    msg("helo\n");
+    return 0;
+}

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -140,7 +140,10 @@ sema_up (struct semaphore *sema) {
 	sema->value++;
 	intr_set_level (old_level);
 	if (t != NULL && t->priority > thread_current()->priority) {
-		thread_yield();
+		if (intr_context ())
+			intr_yield_on_return ();
+		else
+			thread_yield ();
 	}
 }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -204,6 +204,10 @@ process_wait (tid_t child_tid UNUSED) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
+	int wait = 1000000000;
+	while (wait > 0) {
+		wait --;
+	}
 	return -1;
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -40,10 +40,18 @@ syscall_init (void) {
 /* The main system call interface */
 void
 syscall_handler (struct intr_frame *f UNUSED) {
-	printf("syscall_num: %d, expected value is 10\n", f->R.rax);
-	printf("fd: %d, expected value is 1\n", f->R.rdi);
-	printf("buf: %s, expected value is ??\n", f->R.rsi);
-	printf("size: %d, expected value is 6\n", f->R.rdx);
+	int syscall_num = f->R.rax;
 
+	switch (syscall_num)
+	{
+		case 10:
+			char *buf = (char*) f->R.rsi;
+			int size = (int) f->R.rdx;
+			putbuf(buf, size);
+			break;
+		
+		default:
+			break;
+	}
 	thread_exit ();
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -44,12 +44,17 @@ syscall_handler (struct intr_frame *f UNUSED) {
 
 	switch (syscall_num)
 	{
-		case 10:
+		case SYS_WRITE:
+		{
+			int fd = (int) f->R.rdi;
 			char *buf = (char*) f->R.rsi;
 			int size = (int) f->R.rdx;
-			putbuf(buf, size);
+
+			if (fd == STDOUT_FILENO) {
+				putbuf(buf, size);	
+			}
 			break;
-		
+		}
 		default:
 			break;
 	}

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -55,8 +55,13 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			}
 			break;
 		}
+		case SYS_EXIT:
+		{
+			int status = (int) f->R.rdi;
+			thread_exit ();
+			break;
+		}
 		default:
 			break;
 	}
-	thread_exit ();
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -41,5 +41,9 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f UNUSED) {
 	printf("syscall_num: %d, expected value is 10\n", f->R.rax);
+	printf("fd: %d, expected value is 1\n", f->R.rdi);
+	printf("buf: %s, expected value is ??\n", f->R.rsi);
+	printf("size: %d, expected value is 6\n", f->R.rdx);
+
 	thread_exit ();
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -40,7 +40,6 @@ syscall_init (void) {
 /* The main system call interface */
 void
 syscall_handler (struct intr_frame *f UNUSED) {
-	// TODO: Your implementation goes here.
-	printf ("system call!\n");
+	printf("syscall_num: %d, expected value is 10\n", f->R.rax);
 	thread_exit ();
 }


### PR DESCRIPTION
## 작업 내용

- 유저 프로그램의 `write(STDOUT_FILENO, buffer, size)` 시스템 콜을 커널에서 처리하도록 연결했습니다.
- `SYS_WRITE` 요청 중 `fd == STDOUT_FILENO`인 경우 `putbuf(buffer, size)`로 콘솔에 출력하도록 구현했습니다.
- 유저 프로그램 출력 확인을 위해 `printtest` smoke test를 추가했습니다.

## 구현 범위

- 이번 작업은 stdout 출력 경로 확인을 위한 최소 구현입니다.
- 일반 파일 대상 `write()`는 구현하지 않았습니다.
- 파일 디스크립터 테이블, 파일 쓰기, 유저 포인터 검증은 후속 작업 범위로 남겼습니다.

## 테스트

- `tests/userprog/printtest.output` 실행으로 `msg()` 출력이 콘솔에 전달되는 것을 확인했습니다.
- `write()`의 `buffer`는 `f->R.rsi`, `size`는 `f->R.rdx`에서 전달되는 것을 확인했습니다.

## 참고

- `printf()`와 `msg()`는 내부적으로 `write(STDOUT_FILENO, ...)`를 호출합니다.
- 커널에서는 유저용 `write()`를 다시 호출하지 않고, 콘솔 출력용 `putbuf()`를 사용합니다.

## 한계

- 현재 `process_wait()`는 테스트 프로세스가 바로 종료되지 않도록 임시 대기 방식으로 처리되어 있습니다.
- 이 방식은 실제 wait semantics를 구현한 것이 아니며, 정상적인 프로세스 종료 상태 수집과 자식 프로세스 동기화는 후속 작업에서 구현 해야 합니다.
- `SYS_WRITE`는 현재 `STDOUT_FILENO`만 처리하며, 일반 파일 디스크립터 대상 쓰기와 유저 포인터 검증은 포함하지 않습니다.


Closes #203 