### PR TITLE
Issue 205 argument parsing

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -163,7 +163,7 @@ error:
 int
 process_exec (void *f_name) {
 
-    if ( f_name == NULL)
+    if (f_name == NULL)
 		return -1;
     
 	char *cmd_page = f_name;
@@ -172,18 +172,18 @@ process_exec (void *f_name) {
 	bool success;
 
 	/* We cannot use the intr_frame in the thread structure.
-		* This is because when current thread rescheduled,
-		* it stores the execution information to the member. */
+	* This is because when current thread rescheduled,
+	* it stores the execution information to the member. */
 	struct intr_frame _if;
 	_if.ds = _if.es = _if.ss = SEL_UDSEG;
 	_if.cs = SEL_UCSEG;
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
-	int arg_count=0;
-	char *temp_arg[32]={ 0 };
-	uint64_t addr_arg[32]={ 0 };
+	int arg_count = 0;
+	char *argv_tokens[32] = { 0 };
+	uint64_t arg_addrs[32] = { 0 };
 	char *next_ptr;
-	int i=0;
+	int i = 0;
 
 	arg = strtok_r(f_name, " ", &next_ptr);
 
@@ -194,37 +194,37 @@ process_exec (void *f_name) {
 	success = load (arg, &_if);
 	if (success)
 	{
-		while(arg!=NULL && arg_count < 128)
+		while(arg != NULL && arg_count < 32)
 		{
-			temp_arg[arg_count++] = arg;
-			arg= strtok_r(NULL, " ", &next_ptr);
+			argv_tokens[arg_count++] = arg;
+			arg = strtok_r (NULL, " ", &next_ptr);
 		}
 
 		for(int j = arg_count-1 ; j >= 0; j--)
 		{
-			i=strlen(temp_arg[j])+1;
-			_if.rsp-=i;
-			addr_arg[j]= _if.rsp;
-			memcpy((void*)_if.rsp,temp_arg[j],i);
+			i = strlen(argv_tokens[j]) + 1;
+			_if.rsp -= i;
+			arg_addrs[j] = _if.rsp;
+			memcpy ((void*)_if.rsp, argv_tokens[j], i);
 		}
 
 		int j = _if.rsp % 8;
 		_if.rsp -= j;
-		memset((void *) _if.rsp, 0, j);
+		memset ((void *) _if.rsp, 0, j);
 		_if.rsp -= 8;
-		memset((void *) _if.rsp, 0, 8);
+		memset ((void *) _if.rsp, 0, 8);
 
 		for(int j = arg_count-1 ; j >= 0; j--)
 		{
 			_if.rsp -= 8;
-			memcpy((void *) _if.rsp, &addr_arg[j], 8);
+			memcpy ((void *) _if.rsp, &arg_addrs[j], 8);
 		}
 
-		_if.R.rsi=_if.rsp;
+		_if.R.rsi = _if.rsp;
 		_if.rsp -= 8;
-		memset((void *) _if.rsp, 0, 8);
+		memset ((void *) _if.rsp, 0, 8);
 
-		_if.R.rdi=arg_count;
+		_if.R.rdi = arg_count;
 
 		/* If load failed, quit. */
 		palloc_free_page (cmd_page);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -163,80 +163,81 @@ error:
 int
 process_exec (void *f_name) {
 
-    if ( f_name != NULL)
-    {
-        char *cmd_page = f_name;
-        char *args=NULL;
-        char *arg;
+    if ( f_name == NULL) return -1;
+    
+	char *cmd_page = f_name;
+	char *arg;
 
-        bool success;
+	bool success;
 
-        /* We cannot use the intr_frame in the thread structure.
-         * This is because when current thread rescheduled,
-         * it stores the execution information to the member. */
-        struct intr_frame _if;
-        _if.ds = _if.es = _if.ss = SEL_UDSEG;
-        _if.cs = SEL_UCSEG;
-        _if.eflags = FLAG_IF | FLAG_MBS;
+	/* We cannot use the intr_frame in the thread structure.
+		* This is because when current thread rescheduled,
+		* it stores the execution information to the member. */
+	struct intr_frame _if;
+	_if.ds = _if.es = _if.ss = SEL_UDSEG;
+	_if.cs = SEL_UCSEG;
+	_if.eflags = FLAG_IF | FLAG_MBS;
 
-        int arg_count=0;
-        char *temp_arg[128]={ 0 };
-        uint64_t addr_arg[128]={ 0 };
-        char *next_ptr;
-        int i=0;
+	int arg_count=0;
+	char *temp_arg[128]={ 0 };
+	uint64_t addr_arg[128]={ 0 };
+	char *next_ptr;
+	int i=0;
 
-        arg = strtok_r(f_name, " ", &next_ptr);
+	arg = strtok_r(f_name, " ", &next_ptr);
 
-        /* We first kill the current context */
-        process_cleanup ();
+	/* We first kill the current context */
+	process_cleanup ();
 
-        /* And then load the binary */
-        success = load (arg, &_if);
-        if (success)
-        {
-            while(arg!=NULL && arg_count < 128)
-            {
-                temp_arg[arg_count++] = arg;
-                arg= strtok_r(NULL, " ", &next_ptr);
-            }
+	/* And then load the binary */
+	success = load (arg, &_if);
+	if (success)
+	{
+		while(arg!=NULL && arg_count < 128)
+		{
+			temp_arg[arg_count++] = arg;
+			arg= strtok_r(NULL, " ", &next_ptr);
+		}
 
-            for(int j = arg_count-1 ; j >= 0; j--)
-            {
-                i=strlen(temp_arg[j])+1;
-                _if.rsp-=i;
-                addr_arg[j]= _if.rsp;
-                memcpy((void*)_if.rsp,temp_arg[j],i);
-            }
+		for(int j = arg_count-1 ; j >= 0; j--)
+		{
+			i=strlen(temp_arg[j])+1;
+			_if.rsp-=i;
+			addr_arg[j]= _if.rsp;
+			memcpy((void*)_if.rsp,temp_arg[j],i);
+		}
 
-            int j = _if.rsp % 8;
-            _if.rsp -= j;
-            memset((void *) _if.rsp, 0, j);
-            _if.rsp -= 8;
-            memset((void *) _if.rsp, 0, 8);
+		int j = _if.rsp % 8;
+		_if.rsp -= j;
+		memset((void *) _if.rsp, 0, j);
+		_if.rsp -= 8;
+		memset((void *) _if.rsp, 0, 8);
 
-            for(int j = arg_count-1 ; j >= 0; j--)
-            {
-                _if.rsp -= 8;
-                memcpy((void *) _if.rsp, &addr_arg[j], 8);
-            }
+		for(int j = arg_count-1 ; j >= 0; j--)
+		{
+			_if.rsp -= 8;
+			memcpy((void *) _if.rsp, &addr_arg[j], 8);
+		}
 
-            _if.R.rsi=_if.rsp;
-            _if.rsp -= 8;
-            memset((void *) _if.rsp, 0, 8);
+		_if.R.rsi=_if.rsp;
+		_if.rsp -= 8;
+		memset((void *) _if.rsp, 0, 8);
 
-            _if.R.rdi=arg_count;
+		_if.R.rdi=arg_count;
 
-            /* If load failed, quit. */
-            palloc_free_page (cmd_page);
+		/* If load failed, quit. */
+		palloc_free_page (cmd_page);
 
-            /* Start switched process. */
-            do_iret (&_if);
-            NOT_REACHED ();
-        }
+		/* Start switched process. */
+		do_iret (&_if);
+		NOT_REACHED ();
+	}
 
-        if (!success)
-            return -1;
-    }
+	if (!success){
+		palloc_free_page (cmd_page);
+		return -1;
+	}
+    
 }
 
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -180,8 +180,8 @@ process_exec (void *f_name) {
         _if.eflags = FLAG_IF | FLAG_MBS;
 
         int arg_count=0;
-        char *temp_arg[26]={ 0 };
-        uint64_t addr_arg[26]={ 0 };
+        char *temp_arg[128]={ 0 };
+        uint64_t addr_arg[128]={ 0 };
         char *next_ptr;
         int i=0;
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -163,7 +163,8 @@ error:
 int
 process_exec (void *f_name) {
 
-    if ( f_name == NULL) return -1;
+    if ( f_name == NULL)
+		return -1;
     
 	char *cmd_page = f_name;
 	char *arg;
@@ -179,8 +180,8 @@ process_exec (void *f_name) {
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
 	int arg_count=0;
-	char *temp_arg[128]={ 0 };
-	uint64_t addr_arg[128]={ 0 };
+	char *temp_arg[32]={ 0 };
+	uint64_t addr_arg[32]={ 0 };
 	char *next_ptr;
 	int i=0;
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -194,7 +194,7 @@ process_exec (void *f_name) {
         success = load (arg, &_if);
         if (success)
         {
-            while(arg!=NULL)
+            while(arg!=NULL && arg_count < 128)
             {
                 temp_arg[arg_count++] = arg;
                 arg= strtok_r(NULL, " ", &next_ptr);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -162,31 +162,81 @@ error:
  * Returns -1 on fail. */
 int
 process_exec (void *f_name) {
-	char *file_name = f_name;
-	bool success;
 
-	/* We cannot use the intr_frame in the thread structure.
-	 * This is because when current thread rescheduled,
-	 * it stores the execution information to the member. */
-	struct intr_frame _if;
-	_if.ds = _if.es = _if.ss = SEL_UDSEG;
-	_if.cs = SEL_UCSEG;
-	_if.eflags = FLAG_IF | FLAG_MBS;
+    if ( f_name != NULL)
+    {
+        char *cmd_page = f_name;
+        char *args=NULL;
+        char *arg;
 
-	/* We first kill the current context */
-	process_cleanup ();
+        bool success;
 
-	/* And then load the binary */
-	success = load (file_name, &_if);
+        /* We cannot use the intr_frame in the thread structure.
+         * This is because when current thread rescheduled,
+         * it stores the execution information to the member. */
+        struct intr_frame _if;
+        _if.ds = _if.es = _if.ss = SEL_UDSEG;
+        _if.cs = SEL_UCSEG;
+        _if.eflags = FLAG_IF | FLAG_MBS;
 
-	/* If load failed, quit. */
-	palloc_free_page (file_name);
-	if (!success)
-		return -1;
+        int arg_count=0;
+        char *temp_arg[26]={ 0 };
+        uint64_t addr_arg[26]={ 0 };
+        char *next_ptr;
+        int i=0;
 
-	/* Start switched process. */
-	do_iret (&_if);
-	NOT_REACHED ();
+        arg = strtok_r(f_name, " ", &next_ptr);
+
+        /* We first kill the current context */
+        process_cleanup ();
+
+        /* And then load the binary */
+        success = load (arg, &_if);
+        if (success)
+        {
+            while(arg!=NULL)
+            {
+                temp_arg[arg_count++] = arg;
+                arg= strtok_r(NULL, " ", &next_ptr);
+            }
+
+            for(int j = arg_count-1 ; j >= 0; j--)
+            {
+                i=strlen(temp_arg[j])+1;
+                _if.rsp-=i;
+                addr_arg[j]= _if.rsp;
+                memcpy((void*)_if.rsp,temp_arg[j],i);
+            }
+
+            int j = _if.rsp % 8;
+            _if.rsp -= j;
+            memset((void *) _if.rsp, 0, j);
+            _if.rsp -= 8;
+            memset((void *) _if.rsp, 0, 8);
+
+            for(int j = arg_count-1 ; j >= 0; j--)
+            {
+                _if.rsp -= 8;
+                memcpy((void *) _if.rsp, &addr_arg[j], 8);
+            }
+
+            _if.R.rsi=_if.rsp;
+            _if.rsp -= 8;
+            memset((void *) _if.rsp, 0, 8);
+
+            _if.R.rdi=arg_count;
+
+            /* If load failed, quit. */
+            palloc_free_page (cmd_page);
+
+            /* Start switched process. */
+            do_iret (&_if);
+            NOT_REACHED ();
+        }
+
+        if (!success)
+            return -1;
+    }
 }
 
 


### PR DESCRIPTION
## 작업 내용

- 커맨드라인 문자열을 공백 기준으로 파싱해 실행 파일 이름과 인자 목록을 분리했습니다.
- `load()`에는 전체 커맨드라인이 아닌 실행 파일 이름만 전달하도록 수정했습니다.
- 유저 프로그램 시작 시 `argc`, `argv`를 전달할 수 있도록 초기 유저 스택을 구성했습니다.
- 인자 문자열을 유저 스택에 복사하고, 각 문자열의 주소를 `argv` 포인터 배열로 배치했습니다.
- `argv[argc] = NULL` sentinel을 추가했습니다.
- `if_->R.rdi`에 `argc`, `if_->R.rsi`에 유저 스택 내 `argv` 주소를 설정했습니다.
- 스택 포인터를 8바이트 정렬에 맞춰 조정했습니다.

## 테스트

- 아직 syscall handler의 `write`, `exit` 구현이 완료되지 않아 `args-*` 테스트의 최종 통과 여부는 확인하지 못했습니다.
- argument parsing 로직 기준으로는 다음 테스트 통과를 목표로 구현했습니다.
  - `args-none`
  - `args-single`
  - `args-multiple`
  - `args-many`
  - `args-dbl-space`

## 참고 사항

- `argv`는 커널 스택의 지역 배열 주소가 아니라 유저 스택 안의 주소를 전달하도록 구성했습니다.
- 이후 `write(stdout)`와 `exit` syscall이 구현되면 `args-*` 테스트 출력으로 검증할 수 있습니다.

close #205 