### PR TITLE
Issue 208 process wait minimum impl

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -1,10 +1,12 @@
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
+#define USERPROG
 
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -85,6 +87,18 @@ typedef int tid_t;
  * only because they are mutually exclusive: only a thread in the
  * ready state is on the run queue, whereas only a thread in the
  * blocked state is on a semaphore wait list. */
+
+#ifdef USERPROG
+struct child_status {
+	tid_t tid;
+	bool exited;
+	bool waited;
+	int exit_code;
+	struct semaphore wait_sema;
+	struct list_elem elem;
+};
+#endif
+
 struct thread {
 	/* Owned by thread.c. */
 	tid_t tid;                          /* Thread identifier. */
@@ -107,6 +121,11 @@ struct thread {
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
+	
+	/* Variables for wait-exit(parent - child) synchronization. */
+	struct list children;
+	struct child_status *wait_status;
+	
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -442,6 +442,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->magic = THREAD_MAGIC;
 	t->waiting_lock = NULL;
 	list_init (&t->donators);
+	list_init (&t->children);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -316,8 +316,9 @@ process_wait (tid_t child_tid UNUSED) {
 		/* after wake up... */
 		list_remove (&cs->elem);
 		int exit_code = cs->exit_code;
+		bool exited = cs->exited;
 		free (cs);
-		if (cs->exited == false) {
+		if (exited == false) {
 			return -1;
 		}
 		return exit_code;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -62,17 +62,23 @@ process_create_initd (const char *file_name) {
 
 	/* current thread-> children 리스트에 새로 만들 thread를 등록할 준비를 함.*/
 	struct child_status *new_cs = malloc(sizeof(struct child_status));
-	if (new_cs != NULL) {
-		new_cs->tid = NULL;
-		new_cs->waited = false;
-		new_cs->exited = false;
-		new_cs->exit_code = NULL;
-		sema_init (&new_cs->wait_sema, 0);
-		list_push_back (&thread_current ()->children, &new_cs->elem);
+	if (new_cs == NULL) {
+		return TID_ERROR;
 	}
+	new_cs->tid = NULL;
+	new_cs->waited = false;
+	new_cs->exited = false;
+	new_cs->exit_code = NULL;
+	sema_init (&new_cs->wait_sema, 0);
+	list_push_back (&thread_current ()->children, &new_cs->elem);
+
+	struct initd_info *ii;
+	ii->cs = &new_cs;
+	ii->f_name = fn_copy;
+
 
 	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create (process_name, PRI_DEFAULT, initd, fn_copy);
+	tid = thread_create (process_name, PRI_DEFAULT, initd, ii);
 	if (tid == TID_ERROR) {
 		palloc_free_page (fn_copy);
 		list_remove (&new_cs->elem);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -68,7 +68,7 @@ process_create_initd (const char *file_name) {
 	new_cs->tid = -1;
 	new_cs->waited = false;
 	new_cs->exited = false;
-	new_cs->exit_code = NULL;
+	new_cs->exit_code = -1;
 	sema_init (&new_cs->wait_sema, 0);
 	list_push_back (&thread_current ()->children, &new_cs->elem);
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -295,11 +295,34 @@ process_wait (tid_t child_tid UNUSED) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
-	int wait = 1000000000;
-	while (wait > 0) {
-		wait --;
+	/*  */
+
+	struct thread* cur = thread_current ();
+	struct child_status *cs = NULL;
+	for (struct list_elem *e = list_begin (&cur->children); 
+		e != list_end(&cur->children); 
+		e = list_next (e)) {
+		cs = list_entry (e, struct child_status, elem);
+		if (cs->tid == child_tid) {
+			break;
+		}
 	}
-	return -1;
+
+	if (cs != NULL) {
+		cs->waited = true;
+		sema_down (&cs->wait_sema);
+
+		/* after wake up... */
+		list_remove (&cs->elem);
+		int exit_code = cs->exit_code;
+		free (cs);
+		if (cs->exited == false) {
+			return -1;
+		}
+		return exit_code;
+	}
+	else 
+		return -1;
 }
 
 /* Exit the process. This function is called by thread_exit (). */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -24,7 +24,7 @@
 
 static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
-static void initd (void *f_name);
+static void initd (void *ii);
 static void __do_fork (void *);
 
 /* General process initializer for initd and other process. */
@@ -72,8 +72,11 @@ process_create_initd (const char *file_name) {
 	sema_init (&new_cs->wait_sema, 0);
 	list_push_back (&thread_current ()->children, &new_cs->elem);
 
-	struct initd_info *ii;
-	ii->cs = &new_cs;
+	struct initd_info *ii = malloc (sizeof (struct initd_info));
+	if (ii == NULL) {
+		return TID_ERROR;
+	}
+	ii->cs = new_cs;
 	ii->f_name = fn_copy;
 
 
@@ -92,9 +95,9 @@ process_create_initd (const char *file_name) {
 
 /* A thread function that launches first user process. */
 static void
-initd (struct initd_info* ii) {
-	char *f_name = ii->f_name;
-	struct child_status *cs = ii->cs;
+initd (void* ii) {
+	char *f_name = ((struct initd_info *) ii)->f_name;
+	struct child_status *cs = ((struct initd_info *) ii)->cs;
 	thread_current ()->wait_status = cs;
 #ifdef VM
 	supplemental_page_table_init (&thread_current ()->spt);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -74,6 +74,8 @@ process_create_initd (const char *file_name) {
 
 	struct initd_info *ii = malloc (sizeof (struct initd_info));
 	if (ii == NULL) {
+		list_remove (&new_cs->elem);
+		free (new_cs);
 		return TID_ERROR;
 	}
 	ii->cs = new_cs;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -62,10 +62,12 @@ process_create_initd (const char *file_name) {
 
 	/* current thread-> children 리스트에 새로 만들 thread를 등록할 준비를 함.*/
 	struct child_status *new_cs = malloc(sizeof(struct child_status));
-	new_cs->tid = NULL;
-	new_cs->waited = false;
-	new_cs->exited = false;
-	new_cs->exit_code = NULL;
+	if (new_cs != NULL) {
+		new_cs->tid = NULL;
+		new_cs->waited = false;
+		new_cs->exited = false;
+		new_cs->exit_code = NULL;
+	}
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (process_name, PRI_DEFAULT, initd, fn_copy);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -65,7 +65,7 @@ process_create_initd (const char *file_name) {
 	if (new_cs == NULL) {
 		return TID_ERROR;
 	}
-	new_cs->tid = NULL;
+	new_cs->tid = -1;
 	new_cs->waited = false;
 	new_cs->exited = false;
 	new_cs->exit_code = NULL;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -306,6 +306,7 @@ process_wait (tid_t child_tid UNUSED) {
 		if (cs->tid == child_tid) {
 			break;
 		}
+		cs = NULL;
 	}
 
 	if (cs != NULL) {

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -33,6 +33,11 @@ process_init (void) {
 	struct thread *current = thread_current ();
 }
 
+struct initd_info {
+	void * f_name;
+	struct child_status *cs;
+};
+
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.
  * The new thread may be scheduled (and may even exit)
  * before process_create_initd() returns. Returns the initd's
@@ -78,7 +83,10 @@ process_create_initd (const char *file_name) {
 
 /* A thread function that launches first user process. */
 static void
-initd (void *f_name) {
+initd (struct initd_info* ii) {
+	char *f_name = ii->f_name;
+	struct child_status *cs = ii->cs;
+	thread_current ()->wait_status = cs;
 #ifdef VM
 	supplemental_page_table_init (&thread_current ()->spt);
 #endif

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -329,10 +329,10 @@ process_wait (tid_t child_tid UNUSED) {
 void
 process_exit (void) {
 	struct thread *curr = thread_current ();
-	/* TODO: Your code goes here.
-	 * TODO: Implement process termination message (see
-	 * TODO: project2/process_termination.html).
-	 * TODO: We recommend you to implement process resource cleanup here. */
+	struct child_status *cs = curr->wait_status;
+
+	printf("%s: exit(%d)\n", curr->name, cs->exit_code);
+
 
 	process_cleanup ();
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -54,12 +54,25 @@ process_create_initd (const char *file_name) {
 	char *save_ptr;
 	strlcpy(process_name, file_name, sizeof process_name);
 	strtok_r(process_name, " ", &save_ptr);
-	
+
+	/* current thread-> children 리스트에 새로 만들 thread를 등록할 준비를 함.*/
+	struct child_status *new_cs = malloc(sizeof(struct child_status));
+	new_cs->tid = NULL;
+	new_cs->waited = false;
+	new_cs->exited = false;
+	new_cs->exit_code = NULL;
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (process_name, PRI_DEFAULT, initd, fn_copy);
-	if (tid == TID_ERROR)
+	if (tid == TID_ERROR) {
 		palloc_free_page (fn_copy);
+		free (new_cs);
+	} else {
+		new_cs->tid = tid;
+		sema_init (&new_cs->wait_sema, 0);
+		list_push_back (&thread_current ()->children, &new_cs->elem);
+	}
+		
 	return tid;
 }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -333,10 +333,13 @@ process_exit (void) {
 	struct thread *curr = thread_current ();
 	struct child_status *cs = curr->wait_status;
 
-	printf("%s: exit(%d)\n", curr->name, cs->exit_code);
+	if (cs != NULL) {
+		printf("%s: exit(%d)\n", curr->name, cs->exit_code);
 
-	cs->exited = true;
-	sema_up (&cs->wait_sema);
+		cs->exited = true;
+		sema_up (&cs->wait_sema);
+	}
+	
 
 	process_cleanup ();
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -333,6 +333,8 @@ process_exit (void) {
 
 	printf("%s: exit(%d)\n", curr->name, cs->exit_code);
 
+	cs->exited = true;
+	sema_up (&cs->wait_sema);
 
 	process_cleanup ();
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -86,6 +86,7 @@ process_create_initd (const char *file_name) {
 		palloc_free_page (fn_copy);
 		list_remove (&new_cs->elem);
 		free (new_cs);
+		free(ii);
 	} else {
 		new_cs->tid = tid;
 	}
@@ -99,6 +100,7 @@ initd (void* ii) {
 	char *f_name = ((struct initd_info *) ii)->f_name;
 	struct child_status *cs = ((struct initd_info *) ii)->cs;
 	thread_current ()->wait_status = cs;
+	free(ii);
 #ifdef VM
 	supplemental_page_table_init (&thread_current ()->spt);
 #endif

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -67,17 +67,18 @@ process_create_initd (const char *file_name) {
 		new_cs->waited = false;
 		new_cs->exited = false;
 		new_cs->exit_code = NULL;
+		sema_init (&new_cs->wait_sema, 0);
+		list_push_back (&thread_current ()->children, &new_cs->elem);
 	}
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (process_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR) {
 		palloc_free_page (fn_copy);
+		list_remove (&new_cs->elem);
 		free (new_cs);
 	} else {
 		new_cs->tid = tid;
-		sema_init (&new_cs->wait_sema, 0);
-		list_push_back (&thread_current ()->children, &new_cs->elem);
 	}
 		
 	return tid;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -58,7 +58,10 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_EXIT:
 		{
 			char *name = thread_current ()->name;
-			thread_current ()->wait_status->exit_code = (int) f->R.rdi;
+			struct child_status *cs = thread_current ()->wait_status;
+			if (cs != NULL) {
+				cs->exit_code = (int) f->R.rdi;
+			}
 
 			thread_exit ();
 			break;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -58,8 +58,8 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_EXIT:
 		{
 			char *name = thread_current ()->name;
-			int status_code = (int) f->R.rdi;
-			printf("%s: exit(%d)\n", name, status_code);
+			thread_current ()->wait_status->exit_code = (int) f->R.rdi;
+
 			thread_exit ();
 			break;
 		}


### PR DESCRIPTION
## 변경 사항

* `struct child_status`를 추가해 initd 종료 상태를 parent가 추적할 수 있는 기반을 만들었습니다.
* `struct thread`에 `children`, `wait_status` 필드를 추가했습니다.
* `init_thread()`에서 `children` list를 초기화하도록 했습니다.
* `process_create_initd()`에서 initd용 `child_status`를 생성하고 parent의 `children` list에 등록하도록 했습니다.
* initd thread가 parent가 만든 `child_status`를 참조할 수 있도록 `initd_info` aux 구조를 추가했습니다.

## 테스트 방법

1. `pintos/include/threads/thread.h`에서 `child_status`, `children`, `wait_status` 필드가 추가되었는지 확인합니다.
2. `pintos/threads/thread.c`에서 `children` list가 초기화되는지 확인합니다.
3. `pintos/userprog/process.c`에서 initd 생성 시 `child_status`가 생성되고 parent `children` list에 등록되는지 확인합니다.
4. `process_wait()`와 `process_exit()`의 실제 semaphore 연결은 후속 커밋/PR 범위인지 확인합니다.

## 테스트 결과
- 기존에 통과하던 args-*, exit, halt 모두 통과함을 확인했습니다.
- 기존 테스트를 수행하는데 들던 시간보다 테스트가 빠르게 통과합니다!!! 매우 기분이 좋습니다.

## 리뷰어가 확인할 것

* [ ] `child_status` 구조체 필드가 wait-exit 동기화에 필요한 최소 상태를 담고 있는가?
* [ ] `children` list 초기화 위치가 적절한가?
* [ ] initd 생성 시 parent-child 상태 객체 연결 방향이 적절한가?
* [ ] `initd_info` aux 전달 방식에 타입/메모리 관리 문제가 없는가?
* [ ] 이번 변경 범위가 B0 initd run/wait minimal 기반 작업에 맞게 제한되어 있는가?

## 관련 이슈

Closes #208
