### PR TITLE
B3 exit/halt syscall formalization

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -107,6 +107,8 @@ struct thread {
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
+    int exit_status;  //칸을 만든 것 user process가 종료될 때 남기는 상태 정보 
+
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -439,6 +439,9 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->base_priority = priority;
+	#ifdef USERPROG
+	    t->exit_status = -1; //이 thread의 종료 상태 기본값을 -1로 저장한다
+	#endif
 	t->magic = THREAD_MAGIC;
 	t->waiting_lock = NULL;
 	list_init (&t->donators);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -100,6 +100,7 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
 
 	/* 2. Resolve VA from the parent's page map level 4. */
+	
 	parent_page = pml4_get_page (parent->pml4, va);
 
 	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
@@ -278,6 +279,11 @@ process_exit (void) {
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
 
+	if (curr->pml4 != NULL){ //이 프로세스가 user process인 경우에만 종료 메시지를 출력한다.
+	    printf("%s: exit(%d)\n", curr->name, curr->exit_status); //프로그램 이름과 종료 상태를 출력한다.
+
+
+	} 
 	process_cleanup ();
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -40,7 +40,7 @@ syscall_init (void) {
 
 /* The main system call interface */
 void
-syscall_handler (struct intr_frame *f UNUSED) {
+syscall_handler (struct intr_frame *f) {
 	int syscall_num = f->R.rax;
 
 	switch (syscall_num)

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -58,10 +58,10 @@ syscall_handler (struct intr_frame *f) {
 		}
 		case SYS_EXIT:
 		{
-			char *name = thread_current ()->name;
-			int status_code = (int) f->R.rdi;
-			printf("%s: exit(%d)\n", name, status_code);
-			thread_exit ();
+        case SYS_HALT:
+		{
+			printf("Syetem Halted\n");
+			power_off();
 			break;
 		}
 		default:

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -71,6 +71,8 @@ syscall_handler (struct intr_frame *f) {
 			break;
 		}
 		default:
+		    thread_current()->exit_status = -1;
+			thread_exit(); //알 수 없는 syscall이 들어오면 비정상 종료 상태(-1)를 저장하고 종료한다
 			break;
 	}
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -58,6 +58,12 @@ syscall_handler (struct intr_frame *f) {
 		}
 		case SYS_EXIT:
 		{
+			#ifdef USERPROG
+			thread_current()->exit_status = (int) f->R.rdi;
+			thread_exit();
+			#endif
+			break;
+		}
         case SYS_HALT:
 		{
 			printf("Syetem Halted\n");

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -53,6 +53,7 @@ syscall_handler (struct intr_frame *f) {
 
 			if (fd == STDOUT_FILENO) {
 				putbuf(buf, size);	
+				f->R.rax = size;	// write()의 반환값으로 출력한 바이트 수를 돌려준다.
 			}
 			break;
 		}

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -7,6 +7,7 @@
 #include "userprog/gdt.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
+#include "threads/init.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -52,13 +52,13 @@ syscall_handler (struct intr_frame *f) {
 			int size = (int) f->R.rdx;
 
 			if (fd == STDOUT_FILENO) {
-				putbuf(buf, size);	
+				putbuf(buf, size);
 				f->R.rax = size;	// write()의 반환값으로 출력한 바이트 수를 돌려준다.
 			}
 			break;
 		}
 		case SYS_EXIT:
-		{
+		{ 
 			#ifdef USERPROG
 			thread_current()->exit_status = (int) f->R.rdi;
 			thread_exit();
@@ -74,6 +74,6 @@ syscall_handler (struct intr_frame *f) {
 		default:
 		    thread_current()->exit_status = -1;
 			thread_exit(); //알 수 없는 syscall이 들어오면 비정상 종료 상태(-1)를 저장하고 종료한다
-			break;
+            break;
 	}
 }


### PR DESCRIPTION
Closes #212

## Summary
- thread에 exit_status 필드를 추가하고 기본값을 초기화했습니다.
- SYS_HALT, SYS_EXIT, SYS_WRITE의 최소 syscall 동작을 보강했습니다.
- process_exit()에서 user process 종료 메시지를 담당하도록 정리했습니다.
- 알 수 없는 syscall은 exit_status -1로 종료하도록 처리했습니다.

## Test Plan
- 아직 별도 전체 테스트는 수행하지 않았습니다.
- 확인 대상: halt, exit, args-* 회귀 테스트