### PR TITLE
feat: exec basic load failure

### DIFF
--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -139,18 +139,19 @@ page_fault (struct intr_frame *f) {
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
+
+#ifdef VM
+	/* For project 3 and later. */
+	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
+		return;
+#endif
+
 #ifdef USERPROG
 	if ( user == true )
 	{
 		thread_current()->exit_status = -1;
 		thread_exit();
 	}
-#endif
-
-#ifdef VM
-	/* For project 3 and later. */
-	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
-		return;
 #endif
 
 	/* Count page faults. */

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -47,9 +47,9 @@ is_valid_ptr(char *buf)
 static bool
 is_valid_buffer(char *buf, int size)
 {
-	for(int64_t i = pg_round_down (buf) ; i < buf + size - 1 ; i += PGSIZE)
+	for(uintptr_t i = (uintptr_t)pg_round_down(buf) ; i < (uintptr_t)buf + size - 1 ; i += PGSIZE)
 	{
-		if( !is_user_vaddr(i) || pml4_get_page (thread_current ()->pml4, i ) == NULL)
+		if( !is_user_vaddr((void*) i) || pml4_get_page (thread_current ()->pml4, i ) == NULL)
 		{
 			return false;
 		}
@@ -179,10 +179,7 @@ syscall_handler (struct intr_frame *f) {
 
 		case SYS_EXIT:
 		{ 
-			#ifdef USERPROG
-			thread_current()->exit_status = (int) f->R.rdi;
-			thread_exit();
-			#endif
+			sys_exit ( (int)f->R.rdi);
 			break;
 		}
         case SYS_HALT:
@@ -192,8 +189,7 @@ syscall_handler (struct intr_frame *f) {
 			break;
 		}
 		default:
-		    thread_current()->exit_status = -1;
-			thread_exit(); //알 수 없는 syscall이 들어오면 비정상 종료 상태(-1)를 저장하고 종료한다
+		    sys_exit(-1);
             break;
 	}
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -74,8 +74,10 @@ is_valid_string(char *buf)
 }
 static void
 sys_exit (int status) {
-  struct thread *curr = thread_current ();
+#ifdef USERPROG
+	struct thread *curr = thread_current ();
   curr->exit_status = status;
+#endif
   thread_exit ();
 }
 /* The main system call interface */


### PR DESCRIPTION
## 변경 사항

- `origin/feat/userprog` 변경 사항을 `issue-217-b9-exec-basic-load-failure` 브랜치에 반영했습니다.
- `SYS_READ`를 구현해 파일 fd, stdin, stdout 정책을 처리했습니다.
- `SYS_FILESIZE`를 구현해 fd 기반 파일 길이를 반환하도록 했습니다.
- `fork` 시 부모의 fd table을 자식에게 복사하도록 반영했습니다.
- `process_fork()`에서 자식 초기화 실패 시 `TID_ERROR`를 반환하도록 처리했습니다.
- `exec` 이후 fd table이 유지되는지 `exec-read` 테스트로 확인했습니다.
- `threads` 빌드에서 `USERPROG`가 강제로 켜지던 문제를 수정했습니다.
  - `thread.h`의 `#define USERPROG` 제거
  - 이 문제로 `alarm-*` 테스트 빌드 시 userprog 심볼 링크 에러가 발생했습니다.

## 테스트 방법

1. `pintos/userprog`에서 빌드가 통과하는지 확인했습니다.
2. `exec-read` 테스트가 통과하는지 확인했습니다.
   - `pass tests/userprog/exec-read`
3. `pintos/threads`에서 alarm 계열 테스트가 통과하는지 확인했습니다.
   - `pass tests/threads/alarm-single`
   - `pass tests/threads/alarm-multiple`
   - `pass tests/threads/alarm-simultaneous`
   - `pass tests/threads/alarm-priority`
   - `pass tests/threads/alarm-zero`
   - `pass tests/threads/alarm-negative`

## 리뷰어가 확인할 것

- [ ] `process_exec()` 경로에서 fd table이 닫히지 않고 유지되는가?
- [ ] fd cleanup이 `process_exit()`에서만 수행되는가?
- [ ] `SYS_READ`가 stdin/stdout/일반 파일 fd를 의도대로 구분하는가?
- [ ] `fork` 실패 경로에서 자원 누수 없이 `TID_ERROR`가 반환되는가?
- [ ] `thread.h`에서 `USERPROG`를 직접 define하지 않아 threads 빌드가 깨지지 않는가?
- [ ] 불필요한 테스트 기록 파일이나 빌드 산출물이 PR에 포함되지 않았는가?

## 관련 이슈

Closes #217
