### PR TITLE
B11: wait + child status 정식화

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -91,6 +91,7 @@ struct child_status {
 	tid_t tid;
 	bool exited;
 	bool waited;
+	bool parent_alive; // 부모가 살아있는지 여부. 부모가 죽으면 자식은 더이상 기다릴 필요가 없으므로 이 변수를 추가한다.
 	int exit_code;
 	struct semaphore wait_sema;
 	struct list_elem elem;

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -451,8 +451,12 @@ process_exit (void) {
 	if (cs != NULL) {
 		if (curr->pml4 != NULL)
 			printf("%s: exit(%d)\n", curr->name, cs->exit_code);
+		
 		cs->exited = true;
 		sema_up (&cs->wait_sema);
+
+		if (!cs->parent_alive)
+			free (cs);
 	}
 	process_cleanup ();
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -436,6 +436,16 @@ process_exit (void) {
 		file_close(entry->file);
 		free(entry);
 	}
+	while (!list_empty (&curr->children)) {
+		e = list_begin (&curr->children);
+		struct child_status *child_cs = list_entry (e, struct child_status, elem);
+		list_remove (e);
+
+		if (child_cs->exited)
+			free (child_cs);
+		else
+			child_cs->parent_alive = false;
+	}
 	struct child_status *cs = curr->wait_status;
 
 	if (cs != NULL) {

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -436,16 +436,7 @@ process_exit (void) {
 		file_close(entry->file);
 		free(entry);
 	}
-	while (!list_empty (&curr->children)) {
-		e = list_begin (&curr->children);
-		struct child_status *child_cs = list_entry (e, struct child_status, elem);
-		list_remove (e);
 
-		if (child_cs->exited)
-			free (child_cs);
-		else
-			child_cs->parent_alive = false;
-	}
 	struct child_status *cs = curr->wait_status;
 
 	if (cs != NULL) {

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -50,6 +50,7 @@ init_child_status (struct thread* current) {
 	cs->tid = -1;
 	cs->waited = false;
 	cs->exited = false;
+	cs->parent_alive = true; //init_child_status()로 만든 자식 기록지에 “부모는 살아있다”를 기본값으로 넣는 것.
 	cs->exit_code = -1;
 	sema_init (&cs->wait_sema, 0);
 	list_push_back (&thread_current ()->children, &cs->elem);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -160,6 +160,7 @@ process_fork (const char *name, struct intr_frame *if_ UNUSED) {
 	cs->tid = -1;
 	cs->waited = false;
 	cs->exited = false;
+	cs->parent_alive = true; //init_child_status()로 만든 자식 기록지에 “부모는 살아있다”를 기본값으로 넣는 것.
 	cs->exit_code = -1; // fork로 자식 기록지 cs 만들었을 때, 기본 종료값 -1설정. 자식이 비정상 종료 되었을때 대비한 기본값.
 	sema_init (&cs->wait_sema, 0);
 	list_push_back (&thread_current ()->children, &cs->elem);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -159,6 +159,7 @@ process_fork (const char *name, struct intr_frame *if_ UNUSED) {
 	cs->tid = -1;
 	cs->waited = true;
 	cs->exited = false;
+	cs->exit_code = -1; // fork로 자식 기록지 cs 만들었을 때, 기본 종료값 -1설정. 자식이 비정상 종료 되었을때 대비한 기본값.
 	sema_init (&cs->wait_sema, 0);
 	list_push_back (&thread_current ()->children, &cs->elem);
 	

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -445,9 +445,6 @@ process_exit (void) {
 		
 		cs->exited = true;
 		sema_up (&cs->wait_sema);
-
-		if (!cs->parent_alive)
-			free (cs);
 	}
 	process_cleanup ();
 }

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -402,6 +402,10 @@ process_wait (tid_t child_tid UNUSED) {
 		return -1;
 	}
 
+	if (cs->waited) {
+		return -1;
+	}
+
 	cs->waited = true;
 	sema_down (&cs->wait_sema);
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -158,7 +158,7 @@ process_fork (const char *name, struct intr_frame *if_ UNUSED) {
 	}
 	fi->cs = cs;
 	cs->tid = -1;
-	cs->waited = true;
+	cs->waited = false;
 	cs->exited = false;
 	cs->exit_code = -1; // fork로 자식 기록지 cs 만들었을 때, 기본 종료값 -1설정. 자식이 비정상 종료 되었을때 대비한 기본값.
 	sema_init (&cs->wait_sema, 0);


### PR DESCRIPTION
## Summary
- Closes #218
- child_status에 parent_alive를 추가해 부모 선종료 상황을 추적합니다.
- fork/initd child_status 초기값을 정리합니다.
- process_wait()의 중복 wait 방어와 process_exit() cleanup 경로를 보강합니다.

## Notes
- wait-simple/wait-twice는 fork + exec + wait 흐름을 함께 사용하므로 B9/B10 구현 상태에 영향을 받습니다.
- 현재 PR은 B11 범위의 child status/wait cleanup 정식화에 초점을 둡니다.