### PR TITLE
feat: B13 실행 파일 쓰기 방지 처리 구현

### DIFF
--- a/docs/poject2/2026-05-06-b13-rox-dup2-oom.md
+++ b/docs/poject2/2026-05-06-b13-rox-dup2-oom.md
@@ -1,0 +1,143 @@
+# B13 ROX / dup2 / multi-oom 작업 정리
+
+이 문서는 코드를 바로 쓰기 전에 B13에서 무엇을 구현해야 하는지 쉽게 풀어쓴 메모다.
+
+## load 위치
+
+`load()`는 `pintos/userprog/process.c` 안에 있다.
+
+- 선언 위치: 파일 위쪽의 `static bool load (...)`
+- 호출 위치: `process_exec()` 안에서 새 프로그램을 올릴 때 호출
+- 구현 위치: `process.c` 중간 이후의 `static bool load (const char *file_name, struct intr_frame *if_)`
+
+흐름은 대략 이렇다.
+
+1. `exec()` syscall이 들어온다.
+2. `syscall_handler()`가 `process_exec()`를 부른다.
+3. `process_exec()`가 기존 주소 공간을 정리한다.
+4. `process_exec()`가 `load()`를 불러 새 실행 파일을 메모리에 올린다.
+5. `load()`가 성공하면 새 프로그램으로 진입한다.
+
+따라서 ROX에서 말하는 "실행 파일을 열고 deny write를 걸 위치"는 `load()` 근처다.
+
+## B13을 왜 하는가
+
+B13은 Project 2 마무리 성격이다. 새 syscall 하나만 붙이는 작업이 아니라, 지금까지 만든 process, fd, fork, exec, wait가 실패 상황에서도 깨지지 않는지 확인하는 단계다.
+
+큰 덩어리는 세 개다.
+
+1. 실행 중인 파일에 write를 막는 ROX
+2. fd 번호를 복제하는 `dup2`
+3. 메모리 부족 상황에서 자원 정리가 되는지 보는 `multi-oom`
+
+## 1. ROX
+
+ROX는 "실행 중인 프로그램 파일은 쓰면 안 된다"는 기능이다.
+
+예를 들어 `rox-simple`이 실행 중이면, 그 프로세스의 실행 파일에 다시 write를 시도해도 성공하면 안 된다. 실행 중인 코드가 디스크에서 바뀌면 안 되기 때문이다.
+
+해야 할 일은 다음과 같다.
+
+1. 현재 실행 중인 파일을 process/thread가 기억하게 한다.
+2. `load()`에서 실행 파일을 열고 load에 성공하면 그 파일에 `deny write`를 건다.
+3. load 성공 후에는 그 파일을 바로 닫지 않는다.
+4. 프로세스가 종료될 때 `allow write`를 풀고 파일을 닫는다.
+5. load 실패 시에는 실행 파일로 저장하지 않고 그냥 정리한다.
+
+중요한 구분은 이거다.
+
+- 일반 fd table에 들어간 파일: 사용자가 `open()`으로 연 파일
+- 실행 파일 포인터: 현재 프로세스가 실행 중인 파일
+
+이 둘은 헷갈리면 안 된다. 실행 파일은 fd table cleanup과 별개로 `process_exit()`에서 따로 정리하는 쪽이 안전하다.
+
+ROX 관련 테스트는 다음을 본다.
+
+- `rox-simple`: 자기 실행 파일에 write가 막히는가
+- `rox-child`: 자식이 실행 중인 파일도 write가 막히는가
+- `rox-multichild`: 여러 자식이 같은 실행 파일을 실행해도 write deny가 유지되는가
+
+## 2. dup2
+
+`dup2(oldfd, newfd)`는 `newfd`가 `oldfd`와 같은 열린 파일 상태를 가리키게 만드는 기능이다.
+
+예시는 이렇다.
+
+```text
+dup2(3, 5)
+
+전:
+3 -> sample.txt
+5 -> 다른 파일 또는 비어 있음
+
+후:
+3 -> sample.txt
+5 -> sample.txt
+```
+
+주의할 점은 "같은 파일 이름을 새로 open"하는 것이 아니라는 점이다. 같은 열린 파일 상태를 공유해야 한다. 그래야 file offset도 공유된다.
+
+해야 할 일은 다음과 같다.
+
+1. `SYS_DUP2` case를 syscall handler에 추가한다.
+2. `oldfd`가 유효하지 않으면 실패한다.
+3. `oldfd == newfd`이면 아무것도 하지 않고 `newfd`를 반환한다.
+4. `newfd`가 이미 열려 있으면 먼저 닫는다.
+5. `newfd`가 `oldfd`와 같은 열린 파일 상태를 가리키게 fd entry를 만든다.
+
+현재 fd 구조가 단순히 `struct file *`만 들고 있다면 dup2를 제대로 하기가 애매하다. 같은 file 객체를 여러 fd가 공유하면 close 시점에 누가 진짜로 닫아야 하는지 문제가 생긴다.
+
+그래서 dup2까지 제대로 하려면 shared handle 구조를 고려해야 한다.
+
+개념은 이렇다.
+
+```text
+fd_entry
+  fd 번호
+  file_handle을 가리킴
+
+file_handle
+  실제 struct file *
+  이 파일을 가리키는 fd 개수
+```
+
+close할 때는 fd entry만 지우고, handle의 참조 수를 줄인다. 참조 수가 0이 될 때만 실제 `file_close()`를 한다.
+
+## 3. multi-oom
+
+`multi-oom`은 기능 하나를 새로 추가하는 테스트라기보다 실패 경로 정리 테스트다.
+
+메모리가 부족해져서 fork, fd 복사, page 복사, child status 생성 등이 실패할 때 커널이 죽지 않고 정리해야 한다.
+
+확인할 곳은 다음과 같다.
+
+1. `process_fork()`에서 구조체 할당 실패 시 정리되는가
+2. `__do_fork()`에서 page table 복사 실패 시 정리되는가
+3. fork 중 fd table 복사 실패 시 이미 복사한 fd들이 닫히는가
+4. child status를 부모 list에 넣었다가 실패하면 제거되는가
+5. child가 실패했을 때 부모가 `TID_ERROR`를 받는가
+6. wait한 child status가 한 번만 정리되는가
+7. process exit에서 fd와 실행 파일이 모두 정리되는가
+
+multi-oom은 작은 누수나 실패 경로 누락이 있으면 뒤에서 터진다. 따라서 ROX와 dup2보다 나중에 보는 게 좋다.
+
+## 추천 작업 순서
+
+1. 현재 작업 중인 B8/B9 수정 상태를 먼저 정리한다.
+2. ROX를 먼저 구현한다.
+3. `rox-simple`, `rox-child`, `rox-multichild`를 돌린다.
+4. fd 구조가 dup2를 감당할 수 있는지 본다.
+5. 필요하면 fd shared handle 구조를 만든다.
+6. `SYS_DUP2`를 구현한다.
+7. dup2 관련 테스트가 있으면 돌린다.
+8. 마지막으로 `multi-oom`을 돌리고 실패 경로 cleanup을 고친다.
+
+## 헷갈리면 이렇게 구분한다
+
+- `load()`: 실행 파일을 메모리에 올리는 곳
+- `process_exec()`: 현재 프로세스를 새 프로그램으로 바꾸는 곳
+- `process_exit()`: 프로세스가 끝날 때 모든 자원을 정리하는 곳
+- fd table: 사용자가 `open()`으로 얻은 fd들을 관리하는 곳
+- running file: 현재 실행 중인 프로그램 파일을 write 금지 상태로 들고 있는 것
+
+ROX는 `load()`와 `process_exit()`가 중심이고, dup2는 fd table 구조가 중심이고, multi-oom은 실패 경로 정리가 중심이다.

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -8,7 +8,6 @@
 #ifdef VM
 #include "vm/vm.h"
 #endif
-#define USERPROG
 
 
 /* States in a thread's life cycle. */
@@ -126,6 +125,7 @@ struct thread {
 	/* Variables for wait-exit(parent - child) synchronization. */
 	struct list children;
 	struct child_status *wait_status;
+	struct file *running_file;
 
 #endif
 #ifdef VM

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -298,13 +298,7 @@ thread_tid (void) {
 void
 thread_exit (void) {
 	ASSERT (!intr_context ());
-
 #ifdef USERPROG
-	struct thread *t = thread_current ();
-	if ( t->running_file != NULL ){
-		file_allow_write(t->running_file);
-		file_close(t->running_file);
-	}
 	process_exit ();
 #endif
 
@@ -312,7 +306,9 @@ thread_exit (void) {
 	   We will be destroyed during the call to schedule_tail(). */
 	intr_disable ();
 	do_schedule (THREAD_DYING);
+
 	NOT_REACHED ();
+
 }
 
 /* Yields the CPU.  The current thread is not put to sleep and

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -300,6 +300,11 @@ thread_exit (void) {
 	ASSERT (!intr_context ());
 
 #ifdef USERPROG
+	struct thread *t = thread_current ();
+	if ( t->running_file != NULL ){
+		file_allow_write(t->running_file);
+		file_close(t->running_file);
+	}
 	process_exit ();
 #endif
 
@@ -444,6 +449,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->waiting_lock = NULL;
 	list_init (&t->donators);
 #ifdef USERPROG
+	t->running_file = NULL;
 	list_init (&t->fd_table);
 	list_init (&t->children);
 #endif

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -343,8 +343,10 @@ process_exec (void *f_name) {
 
 	/* And then load the binary */
 	success = load (arg, &_if);
+	
 	if (success)
 	{
+		
 		while(arg != NULL && arg_count < 32)
 		{
 			argv_tokens[arg_count++] = arg;
@@ -459,7 +461,7 @@ process_exit (void) {
 		file_close (entry->file);
 		free(entry);
 	}
-
+#ifdef USERPROG
 	struct child_status *cs = curr->wait_status;
 
 	if (cs != NULL) {
@@ -469,6 +471,8 @@ process_exit (void) {
 		cs->exited = true;
 		sema_up (&cs->wait_sema);
 	}
+
+#endif
 	process_cleanup ();
 }
 
@@ -669,8 +673,13 @@ load (const char *file_name, struct intr_frame *if_) {
 
 	/* TODO: Your code goes here.
 	 * TODO: Implement argument passing (see project2/argument_passing.html). */
-
 	success = true;
+#ifdef USERPROG
+	t->running_file = file;
+	file_deny_write(file);
+	return success;
+#endif
+	
 
 done:
 	/* We arrive here whether the load is successful or not. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -462,6 +462,11 @@ process_exit (void) {
 		free(entry);
 	}
 #ifdef USERPROG
+	if ( curr->running_file != NULL ){
+		file_allow_write(curr->running_file);
+		file_close(curr->running_file);
+		curr->running_file = NULL;
+	}
 	struct child_status *cs = curr->wait_status;
 
 	if (cs != NULL) {
@@ -677,11 +682,10 @@ load (const char *file_name, struct intr_frame *if_) {
 #ifdef USERPROG
 	t->running_file = file;
 	file_deny_write(file);
-	return success;
+	file = NULL;	
 #endif
-	
-
 done:
+
 	/* We arrive here whether the load is successful or not. */
 	file_close (file);
 	return success;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -323,13 +323,6 @@ syscall_handler (struct intr_frame *f) {
 			free (fd_entry);
 			break;
 		}
-		case SYS_DUP2:
-		{
-			int fd_1 = f->R.rdi;
-			int fd_2 = f->R.rsi;
-			
-
-		}
 		default:
 			sys_exit (-1);
 			break;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -323,6 +323,13 @@ syscall_handler (struct intr_frame *f) {
 			free (fd_entry);
 			break;
 		}
+		case SYS_DUP2:
+		{
+			int fd_1 = f->R.rdi;
+			int fd_2 = f->R.rsi;
+			
+
+		}
 		default:
 			sys_exit (-1);
 			break;


### PR DESCRIPTION
## 변경 사항

- load 성공 시 실행 중인 executable file을 현재 thread에 저장하고 `file_deny_write()`를 적용했습니다.
- load 실패 시에는 열린 file이 정리되도록 실패 경로를 정리했습니다.
- process 종료 시 executable file의 write deny를 해제하고 file을 닫도록 종료 경로를 정리했습니다.
- `thread_exit()`와 `process_exit()`에서 executable file 정리가 중복되지 않도록 책임 위치를 정리했습니다.

## 테스트 방법

1. `cd pintos/userprog`
2. `make clean && make`
3. `cd build && make tests/userprog/rox-simple.result`
4. `cd build && make tests/userprog/bad-read.result`

## 리뷰어가 확인할 것

- [ ] 변경 범위가 B13 ROX 처리에 필요한 파일로 제한되어 있는가?
- [ ] 기존 Pintos 코드 스타일을 따르는가?
- [ ] load 성공/실패 경로에서 file close 누락이나 중복 close가 없는가?
- [ ] process 종료 경로에서 `file_allow_write()`가 중복 호출되지 않는가?
- [ ] page fault로 종료되는 user process가 kernel panic 없이 `exit(-1)`로 종료되는가?
- [ ] 테스트 결과가 PR 본문에 적혀 있는가?

## 관련 이슈

Closes #227 
