### PR TITLE
Issue 229 b13 dup base work implement

### DIFF
--- a/docs/poject2/2026-05-06-b13-rox-dup2-oom.md
+++ b/docs/poject2/2026-05-06-b13-rox-dup2-oom.md
@@ -1,0 +1,143 @@
+# B13 ROX / dup2 / multi-oom 작업 정리
+
+이 문서는 코드를 바로 쓰기 전에 B13에서 무엇을 구현해야 하는지 쉽게 풀어쓴 메모다.
+
+## load 위치
+
+`load()`는 `pintos/userprog/process.c` 안에 있다.
+
+- 선언 위치: 파일 위쪽의 `static bool load (...)`
+- 호출 위치: `process_exec()` 안에서 새 프로그램을 올릴 때 호출
+- 구현 위치: `process.c` 중간 이후의 `static bool load (const char *file_name, struct intr_frame *if_)`
+
+흐름은 대략 이렇다.
+
+1. `exec()` syscall이 들어온다.
+2. `syscall_handler()`가 `process_exec()`를 부른다.
+3. `process_exec()`가 기존 주소 공간을 정리한다.
+4. `process_exec()`가 `load()`를 불러 새 실행 파일을 메모리에 올린다.
+5. `load()`가 성공하면 새 프로그램으로 진입한다.
+
+따라서 ROX에서 말하는 "실행 파일을 열고 deny write를 걸 위치"는 `load()` 근처다.
+
+## B13을 왜 하는가
+
+B13은 Project 2 마무리 성격이다. 새 syscall 하나만 붙이는 작업이 아니라, 지금까지 만든 process, fd, fork, exec, wait가 실패 상황에서도 깨지지 않는지 확인하는 단계다.
+
+큰 덩어리는 세 개다.
+
+1. 실행 중인 파일에 write를 막는 ROX
+2. fd 번호를 복제하는 `dup2`
+3. 메모리 부족 상황에서 자원 정리가 되는지 보는 `multi-oom`
+
+## 1. ROX
+
+ROX는 "실행 중인 프로그램 파일은 쓰면 안 된다"는 기능이다.
+
+예를 들어 `rox-simple`이 실행 중이면, 그 프로세스의 실행 파일에 다시 write를 시도해도 성공하면 안 된다. 실행 중인 코드가 디스크에서 바뀌면 안 되기 때문이다.
+
+해야 할 일은 다음과 같다.
+
+1. 현재 실행 중인 파일을 process/thread가 기억하게 한다.
+2. `load()`에서 실행 파일을 열고 load에 성공하면 그 파일에 `deny write`를 건다.
+3. load 성공 후에는 그 파일을 바로 닫지 않는다.
+4. 프로세스가 종료될 때 `allow write`를 풀고 파일을 닫는다.
+5. load 실패 시에는 실행 파일로 저장하지 않고 그냥 정리한다.
+
+중요한 구분은 이거다.
+
+- 일반 fd table에 들어간 파일: 사용자가 `open()`으로 연 파일
+- 실행 파일 포인터: 현재 프로세스가 실행 중인 파일
+
+이 둘은 헷갈리면 안 된다. 실행 파일은 fd table cleanup과 별개로 `process_exit()`에서 따로 정리하는 쪽이 안전하다.
+
+ROX 관련 테스트는 다음을 본다.
+
+- `rox-simple`: 자기 실행 파일에 write가 막히는가
+- `rox-child`: 자식이 실행 중인 파일도 write가 막히는가
+- `rox-multichild`: 여러 자식이 같은 실행 파일을 실행해도 write deny가 유지되는가
+
+## 2. dup2
+
+`dup2(oldfd, newfd)`는 `newfd`가 `oldfd`와 같은 열린 파일 상태를 가리키게 만드는 기능이다.
+
+예시는 이렇다.
+
+```text
+dup2(3, 5)
+
+전:
+3 -> sample.txt
+5 -> 다른 파일 또는 비어 있음
+
+후:
+3 -> sample.txt
+5 -> sample.txt
+```
+
+주의할 점은 "같은 파일 이름을 새로 open"하는 것이 아니라는 점이다. 같은 열린 파일 상태를 공유해야 한다. 그래야 file offset도 공유된다.
+
+해야 할 일은 다음과 같다.
+
+1. `SYS_DUP2` case를 syscall handler에 추가한다.
+2. `oldfd`가 유효하지 않으면 실패한다.
+3. `oldfd == newfd`이면 아무것도 하지 않고 `newfd`를 반환한다.
+4. `newfd`가 이미 열려 있으면 먼저 닫는다.
+5. `newfd`가 `oldfd`와 같은 열린 파일 상태를 가리키게 fd entry를 만든다.
+
+현재 fd 구조가 단순히 `struct file *`만 들고 있다면 dup2를 제대로 하기가 애매하다. 같은 file 객체를 여러 fd가 공유하면 close 시점에 누가 진짜로 닫아야 하는지 문제가 생긴다.
+
+그래서 dup2까지 제대로 하려면 shared handle 구조를 고려해야 한다.
+
+개념은 이렇다.
+
+```text
+fd_entry
+  fd 번호
+  file_handle을 가리킴
+
+file_handle
+  실제 struct file *
+  이 파일을 가리키는 fd 개수
+```
+
+close할 때는 fd entry만 지우고, handle의 참조 수를 줄인다. 참조 수가 0이 될 때만 실제 `file_close()`를 한다.
+
+## 3. multi-oom
+
+`multi-oom`은 기능 하나를 새로 추가하는 테스트라기보다 실패 경로 정리 테스트다.
+
+메모리가 부족해져서 fork, fd 복사, page 복사, child status 생성 등이 실패할 때 커널이 죽지 않고 정리해야 한다.
+
+확인할 곳은 다음과 같다.
+
+1. `process_fork()`에서 구조체 할당 실패 시 정리되는가
+2. `__do_fork()`에서 page table 복사 실패 시 정리되는가
+3. fork 중 fd table 복사 실패 시 이미 복사한 fd들이 닫히는가
+4. child status를 부모 list에 넣었다가 실패하면 제거되는가
+5. child가 실패했을 때 부모가 `TID_ERROR`를 받는가
+6. wait한 child status가 한 번만 정리되는가
+7. process exit에서 fd와 실행 파일이 모두 정리되는가
+
+multi-oom은 작은 누수나 실패 경로 누락이 있으면 뒤에서 터진다. 따라서 ROX와 dup2보다 나중에 보는 게 좋다.
+
+## 추천 작업 순서
+
+1. 현재 작업 중인 B8/B9 수정 상태를 먼저 정리한다.
+2. ROX를 먼저 구현한다.
+3. `rox-simple`, `rox-child`, `rox-multichild`를 돌린다.
+4. fd 구조가 dup2를 감당할 수 있는지 본다.
+5. 필요하면 fd shared handle 구조를 만든다.
+6. `SYS_DUP2`를 구현한다.
+7. dup2 관련 테스트가 있으면 돌린다.
+8. 마지막으로 `multi-oom`을 돌리고 실패 경로 cleanup을 고친다.
+
+## 헷갈리면 이렇게 구분한다
+
+- `load()`: 실행 파일을 메모리에 올리는 곳
+- `process_exec()`: 현재 프로세스를 새 프로그램으로 바꾸는 곳
+- `process_exit()`: 프로세스가 끝날 때 모든 자원을 정리하는 곳
+- fd table: 사용자가 `open()`으로 얻은 fd들을 관리하는 곳
+- running file: 현재 실행 중인 프로그램 파일을 write 금지 상태로 들고 있는 것
+
+ROX는 `load()`와 `process_exit()`가 중심이고, dup2는 fd table 구조가 중심이고, multi-oom은 실패 경로 정리가 중심이다.

--- a/docs/poject2/2026-05-06-dup2-current-code.html
+++ b/docs/poject2/2026-05-06-dup2-current-code.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dup2 current code guide</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.65;
+      color: #1f2933;
+      background: #f7f8fa;
+    }
+
+    main {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 40px 22px 72px;
+      background: #ffffff;
+    }
+
+    h1, h2, h3 {
+      line-height: 1.25;
+      color: #111827;
+    }
+
+    h1 {
+      margin-top: 0;
+      font-size: 32px;
+      border-bottom: 2px solid #e5e7eb;
+      padding-bottom: 14px;
+    }
+
+    h2 {
+      margin-top: 42px;
+      font-size: 24px;
+    }
+
+    h3 {
+      margin-top: 28px;
+      font-size: 18px;
+    }
+
+    p {
+      margin: 12px 0;
+    }
+
+    code {
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 0.95em;
+      background: #eef2f7;
+      padding: 2px 5px;
+      border-radius: 4px;
+    }
+
+    pre {
+      overflow-x: auto;
+      background: #111827;
+      color: #f9fafb;
+      padding: 16px;
+      border-radius: 6px;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+
+    pre code {
+      background: transparent;
+      color: inherit;
+      padding: 0;
+      border-radius: 0;
+    }
+
+    ul, ol {
+      padding-left: 24px;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    .note {
+      border-left: 4px solid #2563eb;
+      background: #eff6ff;
+      padding: 12px 14px;
+      margin: 18px 0;
+    }
+  </style>
+</head>
+<body>
+<main>
+  <h1>dup2 current code guide</h1>
+
+  <h2>목적</h2>
+  <p>
+    이 문서는 현재 코드 기준으로 <code>dup2</code>가 왜 필요한지, 기존
+    <code>fd_table</code>과 무엇이 다른지 정리한다.
+  </p>
+  <p>
+    현재 코드에는 기본 file descriptor table은 구현되어 있다. 하지만
+    <code>dup2</code>가 요구하는 "여러 fd가 같은 열린 파일 상태를 공유한다"는
+    구조는 아직 들어가 있지 않다.
+  </p>
+
+  <h2>현재 fd_table 구조</h2>
+  <p>현재 fd entry는 <code>pintos/include/userprog/fd.h</code>에 있다.</p>
+  <pre><code>struct fd_entry {
+	int fd;
+	struct file *file;
+	struct list_elem file_elem;
+};</code></pre>
+
+  <p>각 thread는 <code>struct list fd_table</code>을 가지고 있다.</p>
+  <pre><code>struct list fd_table;</code></pre>
+
+  <p>그리고 thread 초기화 시 <code>fd_table</code>이 초기화된다.</p>
+  <pre><code>list_init (&t-&gt;fd_table);</code></pre>
+
+  <p>즉 현재 구조는 다음과 같다.</p>
+  <pre><code>thread
+  fd_table
+    fd_entry(fd=2) -&gt; struct file *
+    fd_entry(fd=3) -&gt; struct file *
+    fd_entry(fd=4) -&gt; struct file *</code></pre>
+
+  <p>
+    이 구조는 <code>open</code>, <code>read</code>, <code>write</code>,
+    <code>seek</code>, <code>tell</code>, <code>close</code>를 구현하기에는
+    충분하다.
+  </p>
+
+  <h2>현재 syscall 흐름</h2>
+  <p>
+    <code>open</code>은 새 <code>fd_entry</code>를 만들고,
+    <code>fd_table</code>에서 가장 큰 fd보다 1 큰 값을 새 fd로 사용한다.
+  </p>
+  <pre><code>open("sample.txt")
+  filesys_open()
+  fd_entry malloc
+  fd = max_fd + 1
+  fd_entry-&gt;file = file
+  list_push_back(&amp;cur-&gt;fd_table, ...)</code></pre>
+
+  <p>
+    <code>read</code>, <code>write</code>, <code>seek</code>,
+    <code>tell</code>, <code>close</code>는 모두
+    <code>find_fd_entry(fd)</code>로 fd를 찾는다.
+  </p>
+  <pre><code>read(fd)
+  find_fd_entry(fd)
+  file_read(fd_entry-&gt;file, ...)</code></pre>
+
+  <pre><code>write(fd)
+  find_fd_entry(fd)
+  file_write(fd_entry-&gt;file, ...)</code></pre>
+
+  <pre><code>close(fd)
+  find_fd_entry(fd)
+  list_remove()
+  file_close(fd_entry-&gt;file)
+  free(fd_entry)</code></pre>
+
+  <div class="note">
+    여기서 중요한 점은 <code>close(fd)</code>가 곧바로
+    <code>file_close()</code>를 호출한다는 것이다. fd 하나가 file 하나를
+    단독 소유한다는 가정이다.
+  </div>
+
+  <h2>dup2가 요구하는 개념</h2>
+  <p>
+    <code>dup2(oldfd, newfd)</code>는 <code>oldfd</code>가 가리키는 열린
+    파일 상태를 <code>newfd</code>도 가리키게 만든다.
+  </p>
+
+  <pre><code>fd1 = open("sample.txt")
+read(fd1, ..., 10)
+dup2(fd1, fd2)
+read(fd2, ...)</code></pre>
+
+  <p>
+    <code>fd2</code>는 파일 처음부터 다시 읽으면 안 된다.
+    <code>fd1</code>이 이미 10바이트 읽은 상태를 이어받아야 한다.
+  </p>
+
+  <pre><code>fd1 ┐
+    ├── 같은 열린 파일 상태
+fd2 ┘</code></pre>
+
+  <p>여기서 "같은 열린 파일 상태"에는 최소한 다음이 포함된다.</p>
+  <ul>
+    <li>같은 <code>struct file *</code></li>
+    <li>같은 file offset</li>
+    <li>같은 deny write 상태</li>
+    <li>close 시점까지 유지되는 같은 file object</li>
+  </ul>
+
+  <p>
+    따라서 <code>file_duplicate()</code>로 새 <code>struct file *</code>을
+    만드는 것은 <code>fork</code>에는 쓸 수 있지만, <code>dup2</code>의
+    공유 의미와는 다르다. <code>file_duplicate()</code>는 현재 offset을
+    복사한 새 file object를 만들 뿐이고, 이후 offset은 서로 따로 움직인다.
+  </p>
+
+  <h2>현재 코드에서 부족한 부분</h2>
+  <p>현재 <code>SYS_DUP2</code> case는 비어 있다.</p>
+  <pre><code>case SYS_DUP2:
+{
+
+}</code></pre>
+
+  <p>
+    그리고 현재 <code>fd_entry</code>가 <code>struct file *</code>을 직접
+    들고 있기 때문에 다음 문제가 생긴다.
+  </p>
+
+  <pre><code>fd1 -&gt; file
+fd2 -&gt; 같은 file</code></pre>
+
+  <p>
+    이렇게 만들었다고 가정하면, <code>close(fd1)</code>에서 바로
+    <code>file_close(file)</code>을 호출한다. 그러면 <code>fd2</code>가
+    아직 같은 file을 쓰고 있어도 file object가 닫혀 버린다.
+  </p>
+
+  <p>즉 현재 구조 그대로는 <code>dup2</code>를 안전하게 구현하기 어렵다.</p>
+
+  <h2>필요한 구조 변화</h2>
+  <p>
+    <code>dup2</code>를 구현하려면 fd 번호와 실제 열린 file object의 책임을
+    분리하는 편이 좋다.
+  </p>
+
+  <pre><code>struct fd_entry {
+	int fd;
+	struct fd_file *fd_file;
+	struct list_elem file_elem;
+};
+
+struct fd_file {
+	struct file *file;
+	int ref_cnt;
+};</code></pre>
+
+  <p>구조적으로는 이렇게 된다.</p>
+  <pre><code>thread
+  fd_table
+    fd_entry(fd=2) ┐
+                   ├── fd_file(ref_cnt=2) -&gt; struct file *
+    fd_entry(fd=5) ┘</code></pre>
+
+  <p>
+    이제 <code>close(fd)</code>는 <code>fd_entry</code>만 제거하고,
+    <code>ref_cnt</code>를 1 줄인다. <code>ref_cnt</code>가 0이 될 때만
+    실제 <code>file_close()</code>를 호출한다.
+  </p>
+
+  <pre><code>close(fd)
+  fd_entry 제거
+  fd_file-&gt;ref_cnt--
+  if ref_cnt == 0:
+    file_close(fd_file-&gt;file)
+    free(fd_file)
+  free(fd_entry)</code></pre>
+
+  <h2>dup2 동작 규칙</h2>
+
+  <h3>oldfd가 유효하지 않으면 실패</h3>
+  <p><code>oldfd</code>가 <code>fd_table</code>에 없으면 <code>-1</code>을 반환해야 한다.</p>
+  <pre><code>dup2(bad_fd, fd) -&gt; -1</code></pre>
+
+  <h3>oldfd와 newfd가 같으면 그대로 성공</h3>
+  <p>
+    <code>dup2(fd, fd)</code>는 아무것도 바꾸지 않고 <code>fd</code>를
+    반환해야 한다.
+  </p>
+  <pre><code>dup2(fd3, fd3) -&gt; fd3</code></pre>
+
+  <p><code>dup2-complex.c</code>에는 이 형태가 직접 나온다.</p>
+  <pre><code>dup2 (dup2 (fd3, fd3), dup2 (fd1, fd2));</code></pre>
+
+  <h3>newfd가 이미 열려 있으면 먼저 닫는다</h3>
+  <p>
+    <code>dup2(oldfd, newfd)</code>에서 <code>newfd</code>가 이미 사용 중이면,
+    먼저 <code>close(newfd)</code>와 같은 효과가 나야 한다.
+  </p>
+
+  <pre><code>before:
+  oldfd -&gt; A
+  newfd -&gt; B
+
+dup2(oldfd, newfd)
+
+after:
+  oldfd -&gt; A
+  newfd -&gt; A
+  B는 ref_cnt가 0이면 close</code></pre>
+
+  <h3>newfd가 크거나 비어 있어도 지정한 번호를 사용한다</h3>
+  <p>
+    현재 <code>open</code>은 <code>max_fd + 1</code> 방식으로 fd를 만든다.
+    하지만 <code>dup2</code>는 <code>newfd</code>로 들어온 값을 그대로
+    사용해야 한다.
+  </p>
+
+  <pre><code>int fd2 = 0x1CE;
+CHECK (dup2 (fd1, fd2) &gt; 1, "first dup2()");</code></pre>
+
+  <p>
+    따라서 <code>dup2</code>는 비어 있는 fd 중 가장 작은 값을 고르는 syscall이
+    아니다. 사용자가 지정한 <code>newfd</code>를 만드는 syscall이다.
+  </p>
+
+  <h2>stdout과 stdin</h2>
+  <p>테스트에서는 <code>dup2</code>를 stdout에도 사용한다.</p>
+
+  <pre><code>dup2 (1, fd5);
+write (fd5, magic, sizeof magic - 1);</code></pre>
+
+  <p>또 다른 부분에서는 stdout 자체를 file로 바꾼다.</p>
+
+  <pre><code>dup2 (fd6, 1);
+msg ("%d", byte_cnt);</code></pre>
+
+  <p>
+    따라서 <code>dup2</code> 구현은 fd 0, fd 1도 특별히 조심해야 한다.
+    현재 코드는 fd 0과 fd 1을 <code>fd_table</code>에 기본 entry로 넣지 않고,
+    syscall에서 직접 처리한다.
+  </p>
+
+  <pre><code>read(0)  -&gt; input_getc()
+write(1) -&gt; putbuf()</code></pre>
+
+  <p>
+    그러나 <code>dup2(fd6, 1)</code> 이후에는 fd 1이 더 이상 콘솔 stdout이
+    아니라 파일을 가리킬 수 있어야 한다.
+  </p>
+
+  <pre><code>방법 A:
+  fd_table에 fd 0, fd 1 entry도 넣고 stdin/stdout을 일반 fd처럼 다룬다.
+
+방법 B:
+  fd_table에 fd 1 entry가 있으면 write(1)는 그 entry를 우선 사용하고,
+  없을 때만 putbuf()를 사용한다.</code></pre>
+
+  <p>현재 코드와 가장 적게 충돌하는 방향은 B에 가깝다.</p>
+
+  <h2>fork와 dup2의 차이</h2>
+  <p>현재 fork에서는 부모의 fd entry를 돌면서 <code>file_duplicate()</code>를 사용한다.</p>
+
+  <pre><code>new_fde-&gt;file = file_duplicate (fde-&gt;file);</code></pre>
+
+  <p>
+    이것은 부모와 자식이 서로 다른 <code>struct file *</code>을 가지게 한다.
+    따라서 fork 이후 부모와 자식의 file offset은 독립적으로 움직인다.
+  </p>
+
+  <p>
+    반면 dup2는 같은 process 안에서 두 fd가 같은 열린 file object를 공유해야 한다.
+  </p>
+
+  <pre><code>fork fd copy:
+  parent fd3 -&gt; file A
+  child  fd3 -&gt; file B
+
+dup2:
+  fd3 -&gt; file A
+  fd5 -&gt; file A</code></pre>
+
+  <p>
+    그래서 <code>dup2</code> 구현에 <code>file_duplicate()</code>를 그대로 쓰면
+    <code>dup2-simple</code>의 offset 공유 요구를 만족하지 못한다.
+  </p>
+
+  <h2>구현 순서 추천</h2>
+  <ol>
+    <li><code>struct fd_entry</code>가 직접 <code>struct file *</code>을 들지 않도록 공유 구조를 추가한다.</li>
+    <li><code>open</code>에서 새 공유 구조를 만들고 <code>ref_cnt = 1</code>로 시작한다.</li>
+    <li><code>read</code>, <code>write</code>, <code>seek</code>, <code>tell</code>, <code>filesize</code>가 공유 구조 안의 file을 사용하도록 바꾼다.</li>
+    <li><code>close</code>를 helper로 분리하고, ref count가 0일 때만 <code>file_close()</code>를 호출하게 한다.</li>
+    <li>process exit의 fd cleanup도 같은 close helper를 사용하게 한다.</li>
+    <li><code>dup2</code>에서 <code>oldfd</code>를 찾고, 필요하면 <code>newfd</code>를 먼저 닫은 뒤 새 <code>fd_entry</code>를 만들어 같은 공유 구조를 가리키게 한다.</li>
+    <li><code>newfd == oldfd</code>는 바로 <code>newfd</code>를 반환한다.</li>
+    <li>fd 1이 fd_table에 존재하는 경우 <code>write(1)</code>이 putbuf가 아니라 그 file에 쓰도록 처리한다.</li>
+  </ol>
+
+  <h2>확인할 테스트</h2>
+  <p>최소 확인 대상은 다음이다.</p>
+
+  <pre><code>tests/userprog/dup2/dup2-simple
+tests/userprog/dup2/dup2-complex</code></pre>
+
+  <p>회귀 확인으로는 기존 fd syscall 테스트도 같이 보는 것이 좋다.</p>
+
+  <pre><code>read-normal
+write-normal
+seek-simple
+tell-simple
+close-normal
+close-twice
+read-stdout
+write-stdin</code></pre>
+
+  <h2>한 줄 결론</h2>
+  <p>
+    현재 fd_table은 구현되어 있지만, fd 하나가 file 하나를 단독 소유하는
+    구조다. <code>dup2</code>는 여러 fd가 같은 열린 file object와 offset을
+    공유해야 하므로, <code>fd_entry</code>와 실제 file object 사이에 ref count가
+    있는 공유 구조가 필요하다.
+  </p>
+</main>
+</body>
+</html>

--- a/docs/poject2/2026-05-06-dup2-current-code.md
+++ b/docs/poject2/2026-05-06-dup2-current-code.md
@@ -1,0 +1,369 @@
+# dup2 current code guide
+
+## 목적
+
+이 문서는 현재 코드 기준으로 `dup2`가 왜 필요한지, 기존 `fd_table`과
+무엇이 다른지 정리한다.
+
+현재 코드에는 기본 file descriptor table은 구현되어 있다. 하지만
+`dup2`가 요구하는 "여러 fd가 같은 열린 파일 상태를 공유한다"는 구조는
+아직 들어가 있지 않다.
+
+## 현재 fd_table 구조
+
+현재 fd entry는 `pintos/include/userprog/fd.h`에 있다.
+
+```c
+struct fd_entry {
+	int fd;
+	struct file *file;
+	struct list_elem file_elem;
+};
+```
+
+각 thread는 `struct list fd_table`을 가지고 있다.
+
+```c
+struct list fd_table;
+```
+
+그리고 thread 초기화 시 `fd_table`이 초기화된다.
+
+```c
+list_init (&t->fd_table);
+```
+
+즉 현재 구조는 다음과 같다.
+
+```text
+thread
+  fd_table
+    fd_entry(fd=2) -> struct file *
+    fd_entry(fd=3) -> struct file *
+    fd_entry(fd=4) -> struct file *
+```
+
+이 구조는 `open`, `read`, `write`, `seek`, `tell`, `close`를 구현하기에는
+충분하다.
+
+## 현재 syscall 흐름
+
+`open`은 새 `fd_entry`를 만들고, `fd_table`에서 가장 큰 fd보다 1 큰
+값을 새 fd로 사용한다.
+
+```text
+open("sample.txt")
+  filesys_open()
+  fd_entry malloc
+  fd = max_fd + 1
+  fd_entry->file = file
+  list_push_back(&cur->fd_table, ...)
+```
+
+`read`, `write`, `seek`, `tell`, `close`는 모두 `find_fd_entry(fd)`로
+fd를 찾는다.
+
+```text
+read(fd)
+  find_fd_entry(fd)
+  file_read(fd_entry->file, ...)
+```
+
+```text
+write(fd)
+  find_fd_entry(fd)
+  file_write(fd_entry->file, ...)
+```
+
+```text
+close(fd)
+  find_fd_entry(fd)
+  list_remove()
+  file_close(fd_entry->file)
+  free(fd_entry)
+```
+
+여기서 중요한 점은 `close(fd)`가 곧바로 `file_close()`를 호출한다는
+것이다. fd 하나가 file 하나를 단독 소유한다는 가정이다.
+
+## dup2가 요구하는 개념
+
+`dup2(oldfd, newfd)`는 `oldfd`가 가리키는 열린 파일 상태를 `newfd`도
+가리키게 만든다.
+
+예를 들어 다음 상황을 생각한다.
+
+```text
+fd1 = open("sample.txt")
+read(fd1, ..., 10)
+dup2(fd1, fd2)
+read(fd2, ...)
+```
+
+`fd2`는 파일 처음부터 다시 읽으면 안 된다. `fd1`이 이미 10바이트 읽은
+상태를 이어받아야 한다.
+
+즉 `dup2` 이후에는 이렇게 되어야 한다.
+
+```text
+fd1 ┐
+    ├── 같은 열린 파일 상태
+fd2 ┘
+```
+
+여기서 "같은 열린 파일 상태"에는 최소한 다음이 포함된다.
+
+- 같은 `struct file *`
+- 같은 file offset
+- 같은 deny write 상태
+- close 시점까지 유지되는 같은 file object
+
+따라서 `file_duplicate()`로 새 `struct file *`을 만드는 것은 `fork`에는
+쓸 수 있지만, `dup2`의 공유 의미와는 다르다. `file_duplicate()`는 현재
+offset을 복사한 새 file object를 만들 뿐이고, 이후 offset은 서로 따로
+움직인다.
+
+## 현재 코드에서 부족한 부분
+
+현재 `SYS_DUP2` case는 비어 있다.
+
+```c
+case SYS_DUP2:
+{
+
+}
+```
+
+그리고 현재 `fd_entry`가 `struct file *`을 직접 들고 있기 때문에 다음
+문제가 생긴다.
+
+```text
+fd1 -> file
+fd2 -> 같은 file
+```
+
+이렇게 만들었다고 가정하면, `close(fd1)`에서 바로 `file_close(file)`을
+호출한다. 그러면 `fd2`가 아직 같은 file을 쓰고 있어도 file object가
+닫혀 버린다.
+
+즉 현재 구조 그대로는 `dup2`를 안전하게 구현하기 어렵다.
+
+## 필요한 구조 변화
+
+`dup2`를 구현하려면 fd 번호와 실제 열린 file object의 책임을 분리하는
+편이 좋다.
+
+예시 구조는 다음과 같다.
+
+```c
+struct fd_entry {
+	int fd;
+	struct fd_file *fd_file;
+	struct list_elem file_elem;
+};
+
+struct fd_file {
+	struct file *file;
+	int ref_cnt;
+};
+```
+
+구조적으로는 이렇게 된다.
+
+```text
+thread
+  fd_table
+    fd_entry(fd=2) ┐
+                   ├── fd_file(ref_cnt=2) -> struct file *
+    fd_entry(fd=5) ┘
+```
+
+이제 `close(fd)`는 `fd_entry`만 제거하고, `ref_cnt`를 1 줄인다.
+`ref_cnt`가 0이 될 때만 실제 `file_close()`를 호출한다.
+
+```text
+close(fd)
+  fd_entry 제거
+  fd_file->ref_cnt--
+  if ref_cnt == 0:
+    file_close(fd_file->file)
+    free(fd_file)
+  free(fd_entry)
+```
+
+## dup2 동작 규칙
+
+현재 테스트 기준으로 `dup2`는 다음 규칙을 만족해야 한다.
+
+### oldfd가 유효하지 않으면 실패
+
+`oldfd`가 `fd_table`에 없으면 `-1`을 반환해야 한다.
+
+```text
+dup2(bad_fd, fd) -> -1
+```
+
+### oldfd와 newfd가 같으면 그대로 성공
+
+`dup2(fd, fd)`는 아무것도 바꾸지 않고 `fd`를 반환해야 한다.
+
+```text
+dup2(fd3, fd3) -> fd3
+```
+
+`dup2-complex.c`에는 이 형태가 직접 나온다.
+
+```c
+dup2 (dup2 (fd3, fd3), dup2 (fd1, fd2));
+```
+
+### newfd가 이미 열려 있으면 먼저 닫는다
+
+`dup2(oldfd, newfd)`에서 `newfd`가 이미 사용 중이면, 먼저 `close(newfd)`
+와 같은 효과가 나야 한다.
+
+그 다음 `newfd`가 `oldfd`와 같은 열린 file object를 가리키게 한다.
+
+```text
+before:
+  oldfd -> A
+  newfd -> B
+
+dup2(oldfd, newfd)
+
+after:
+  oldfd -> A
+  newfd -> A
+  B는 ref_cnt가 0이면 close
+```
+
+### newfd가 크거나 비어 있어도 지정한 번호를 사용한다
+
+현재 `open`은 `max_fd + 1` 방식으로 fd를 만든다. 하지만 `dup2`는
+`newfd`로 들어온 값을 그대로 사용해야 한다.
+
+`dup2-simple.c`는 일부러 큰 fd를 사용한다.
+
+```c
+int fd2 = 0x1CE;
+CHECK (dup2 (fd1, fd2) > 1, "first dup2()");
+```
+
+따라서 `dup2`는 비어 있는 fd 중 가장 작은 값을 고르는 syscall이 아니다.
+사용자가 지정한 `newfd`를 만드는 syscall이다.
+
+## stdout과 stdin
+
+테스트에서는 `dup2`를 stdout에도 사용한다.
+
+```c
+dup2 (1, fd5);
+write (fd5, magic, sizeof magic - 1);
+```
+
+또 다른 부분에서는 stdout 자체를 file로 바꾼다.
+
+```c
+dup2 (fd6, 1);
+msg ("%d", byte_cnt);
+```
+
+따라서 `dup2` 구현은 fd 0, fd 1도 특별히 조심해야 한다.
+
+현재 코드는 fd 0과 fd 1을 `fd_table`에 기본 entry로 넣지 않는다.
+대신 syscall에서 직접 처리한다.
+
+```text
+read(0)  -> input_getc()
+write(1) -> putbuf()
+```
+
+그러나 `dup2(fd6, 1)` 이후에는 fd 1이 더 이상 콘솔 stdout이 아니라
+파일을 가리킬 수 있어야 한다.
+
+즉 `dup2`를 제대로 구현하려면 다음 정책 중 하나가 필요하다.
+
+```text
+방법 A:
+  fd_table에 fd 0, fd 1 entry도 넣고 stdin/stdout을 일반 fd처럼 다룬다.
+
+방법 B:
+  fd_table에 fd 1 entry가 있으면 write(1)는 그 entry를 우선 사용하고,
+  없을 때만 putbuf()를 사용한다.
+```
+
+현재 코드와 가장 적게 충돌하는 방향은 B에 가깝다.
+
+## fork와 dup2의 차이
+
+현재 fork에서는 부모의 fd entry를 돌면서 `file_duplicate()`를 사용한다.
+
+```c
+new_fde->file = file_duplicate (fde->file);
+```
+
+이것은 부모와 자식이 서로 다른 `struct file *`을 가지게 한다.
+따라서 fork 이후 부모와 자식의 file offset은 독립적으로 움직인다.
+
+반면 dup2는 같은 process 안에서 두 fd가 같은 열린 file object를 공유해야
+한다.
+
+```text
+fork fd copy:
+  parent fd3 -> file A
+  child  fd3 -> file B
+
+dup2:
+  fd3 -> file A
+  fd5 -> file A
+```
+
+그래서 `dup2` 구현에 `file_duplicate()`를 그대로 쓰면 `dup2-simple`의
+offset 공유 요구를 만족하지 못한다.
+
+## 구현 순서 추천
+
+현재 코드에서 구현한다면 순서는 다음이 좋다.
+
+1. `struct fd_entry`가 직접 `struct file *`을 들지 않도록 공유 구조를
+   추가한다.
+2. `open`에서 새 공유 구조를 만들고 `ref_cnt = 1`로 시작한다.
+3. `read`, `write`, `seek`, `tell`, `filesize`가 공유 구조 안의 file을
+   사용하도록 바꾼다.
+4. `close`를 helper로 분리하고, ref count가 0일 때만 `file_close()`를
+   호출하게 한다.
+5. process exit의 fd cleanup도 같은 close helper를 사용하게 한다.
+6. `dup2`에서 `oldfd`를 찾고, 필요하면 `newfd`를 먼저 닫은 뒤 새
+   `fd_entry`를 만들어 같은 공유 구조를 가리키게 한다.
+7. `newfd == oldfd`는 바로 `newfd`를 반환한다.
+8. fd 1이 fd_table에 존재하는 경우 `write(1)`이 putbuf가 아니라 그 file에
+   쓰도록 처리한다.
+
+## 확인할 테스트
+
+최소 확인 대상은 다음이다.
+
+```text
+tests/userprog/dup2/dup2-simple
+tests/userprog/dup2/dup2-complex
+```
+
+회귀 확인으로는 기존 fd syscall 테스트도 같이 보는 것이 좋다.
+
+```text
+read-normal
+write-normal
+seek-simple
+tell-simple
+close-normal
+close-twice
+read-stdout
+write-stdin
+```
+
+## 한 줄 결론
+
+현재 fd_table은 구현되어 있지만, fd 하나가 file 하나를 단독 소유하는
+구조다. `dup2`는 여러 fd가 같은 열린 file object와 offset을 공유해야
+하므로, `fd_entry`와 실제 file object 사이에 ref count가 있는 공유
+구조가 필요하다.

--- a/pintos/.vscode/pintos-test-history.json
+++ b/pintos/.vscode/pintos-test-history.json
@@ -135,5 +135,67 @@
       "last_used": 1777466534.488,
       "last_action": "run"
     }
+  },
+  "userprog": {
+    "tests/userprog/write-zero": {
+      "count": 14,
+      "last_used": 1778062262.086,
+      "last_action": "run"
+    },
+    "tests/userprog/rox-simple": {
+      "count": 22,
+      "last_used": 1778069586.181,
+      "last_action": "run"
+    },
+    "tests/userprog/rox-child": {
+      "count": 22,
+      "last_used": 1778069586.181,
+      "last_action": "run"
+    },
+    "tests/userprog/rox-multichild": {
+      "count": 22,
+      "last_used": 1778069586.181,
+      "last_action": "run"
+    },
+    "tests/userprog/bad-read": {
+      "count": 6,
+      "last_used": 1778062508.277,
+      "last_action": "run"
+    },
+    "tests/userprog/bad-write": {
+      "count": 4,
+      "last_used": 1778062508.277,
+      "last_action": "run"
+    },
+    "tests/userprog/bad-read2": {
+      "count": 4,
+      "last_used": 1778062508.277,
+      "last_action": "run"
+    },
+    "tests/userprog/bad-write2": {
+      "count": 4,
+      "last_used": 1778062508.277,
+      "last_action": "run"
+    },
+    "tests/userprog/bad-jump": {
+      "count": 4,
+      "last_used": 1778062508.277,
+      "last_action": "run"
+    },
+    "tests/userprog/bad-jump2": {
+      "count": 4,
+      "last_used": 1778062508.277,
+      "last_action": "run"
+    },
+    "tests/userprog/dup2/dup2-complex": {
+      "count": 16,
+      "last_used": 1778071382.57,
+      "last_action": "run"
+    },
+    "tests/userprog/dup2/dup2-simple": {
+      "count": 16,
+      "last_used": 1778071382.57,
+      "last_action": "run"
+    }
   }
 }

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -8,7 +8,6 @@
 #ifdef VM
 #include "vm/vm.h"
 #endif
-#define USERPROG
 
 
 /* States in a thread's life cycle. */
@@ -126,6 +125,7 @@ struct thread {
 	/* Variables for wait-exit(parent - child) synchronization. */
 	struct list children;
 	struct child_status *wait_status;
+	struct file *running_file;
 
 #endif
 #ifdef VM

--- a/pintos/include/userprog/fd.h
+++ b/pintos/include/userprog/fd.h
@@ -5,6 +5,8 @@
 
 struct file;
 
+#define FILE_TYPE 3
+
 struct fd_entry {
 	int fd;
 	struct shared_fd *sfd;

--- a/pintos/include/userprog/fd.h
+++ b/pintos/include/userprog/fd.h
@@ -7,8 +7,13 @@ struct file;
 
 struct fd_entry {
 	int fd;
-	struct file *file;
+	struct shared_fd *sfd;
 	struct list_elem file_elem;
+};
+struct shared_fd {
+	int type;
+	int shared_count;
+	struct file *file;
 };
 
 #endif /* userprog/fd.h */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -298,13 +298,7 @@ thread_tid (void) {
 void
 thread_exit (void) {
 	ASSERT (!intr_context ());
-
 #ifdef USERPROG
-	struct thread *t = thread_current ();
-	if ( t->running_file != NULL ){
-		file_allow_write(t->running_file);
-		file_close(t->running_file);
-	}
 	process_exit ();
 #endif
 
@@ -312,7 +306,9 @@ thread_exit (void) {
 	   We will be destroyed during the call to schedule_tail(). */
 	intr_disable ();
 	do_schedule (THREAD_DYING);
+
 	NOT_REACHED ();
+
 }
 
 /* Yields the CPU.  The current thread is not put to sleep and

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -447,7 +447,6 @@ init_thread (struct thread *t, const char *name, int priority) {
 #ifdef USERPROG
 	t->running_file = NULL;
 	list_init (&t->fd_table);
-	t->fd_table
 	list_init (&t->children);
 #endif
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -447,6 +447,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 #ifdef USERPROG
 	t->running_file = NULL;
 	list_init (&t->fd_table);
+	t->fd_table
 	list_init (&t->children);
 #endif
 }

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -300,6 +300,11 @@ thread_exit (void) {
 	ASSERT (!intr_context ());
 
 #ifdef USERPROG
+	struct thread *t = thread_current ();
+	if ( t->running_file != NULL ){
+		file_allow_write(t->running_file);
+		file_close(t->running_file);
+	}
 	process_exit ();
 #endif
 
@@ -444,6 +449,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->waiting_lock = NULL;
 	list_init (&t->donators);
 #ifdef USERPROG
+	t->running_file = NULL;
 	list_init (&t->fd_table);
 	list_init (&t->children);
 #endif

--- a/pintos/userprog/Make.vars
+++ b/pintos/userprog/Make.vars
@@ -6,7 +6,7 @@ KERNEL_SUBDIRS += devices lib lib/kernel userprog filesys
 TEST_SUBDIRS = tests/userprog tests/filesys/base tests/userprog/no-vm tests/threads
 GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.no-extra
 
-# Uncomment the lines below to submit/test extra for project 2.
-# TDEFINE := -DEXTRA2
-# TEST_SUBDIRS += tests/userprog/dup2
-# GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.extra
+# Extra Project 2 tests.
+TDEFINE := -DEXTRA2
+TEST_SUBDIRS += tests/userprog/dup2
+GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.extra

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -28,11 +28,32 @@ static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *ii);
 static void __do_fork (void *);
+static bool is_file_fd (const struct fd_entry *entry);
 
 /* General process initializer for initd and other process. */
 static void
 process_init (void) {
 	struct thread *current = thread_current ();
+
+	struct fd_entry *stdin_fd = malloc (sizeof (struct fd_entry));
+	if (stdin_fd != NULL) {
+		stdin_fd->fd = STDIN_FILENO;
+		stdin_fd->sfd = malloc (sizeof (struct shared_fd));
+		stdin_fd->sfd->type = STDIN_FILENO;
+		list_push_back (&current->fd_table, &stdin_fd->file_elem);
+	}
+	struct fd_entry *stdout_fd = malloc (sizeof (struct fd_entry));
+	if (stdout_fd != NULL) {
+		stdout_fd->fd = STDOUT_FILENO;
+		stdout_fd->sfd = malloc (sizeof (struct shared_fd));
+		stdout_fd->sfd->type = STDOUT_FILENO;
+		list_push_back (&current->fd_table, &stdout_fd->file_elem);
+	}
+}
+
+static bool
+is_file_fd (const struct fd_entry *entry) {
+	return entry->sfd->type == FILE_TYPE;
 }
 
 struct initd_info {
@@ -294,8 +315,10 @@ __do_fork (void *aux) {
 		}
 		new_fde->fd = fde->fd;
 		new_fde->sfd = malloc (sizeof (struct shared_fd));
-		new_fde->sfd->file = file_duplicate (fde->sfd->file);
+		if (is_file_fd (fde))
+			new_fde->sfd->file = file_duplicate (fde->sfd->file);
 		new_fde->sfd->shared_count = 1;
+		new_fde->sfd->type = fde->sfd->type;
 		list_push_back (&current->fd_table, &new_fde->file_elem);
 	}
 
@@ -461,7 +484,7 @@ process_exit (void) {
 		struct fd_entry *entry = list_entry(e, struct fd_entry, file_elem);
 		list_remove(e);
 		entry->sfd->shared_count--;
-		if ( entry->sfd->shared_count == 0 )
+		if (is_file_fd (entry) && entry->sfd->shared_count == 0)
 		{
 			file_close (entry->sfd->file);
 			free (entry->sfd);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -39,15 +39,29 @@ process_init (void) {
 	if (stdin_fd != NULL) {
 		stdin_fd->fd = STDIN_FILENO;
 		stdin_fd->sfd = malloc (sizeof (struct shared_fd));
-		stdin_fd->sfd->type = STDIN_FILENO;
-		list_push_back (&current->fd_table, &stdin_fd->file_elem);
+		if (stdin_fd->sfd == NULL) {
+			free (stdin_fd);
+		}
+		else {
+			stdin_fd->sfd->type = STDIN_FILENO;
+			stdin_fd->sfd->shared_count = 1;
+			stdin_fd->sfd->file = NULL;
+			list_push_back (&current->fd_table, &stdin_fd->file_elem);
+		}
 	}
 	struct fd_entry *stdout_fd = malloc (sizeof (struct fd_entry));
 	if (stdout_fd != NULL) {
 		stdout_fd->fd = STDOUT_FILENO;
 		stdout_fd->sfd = malloc (sizeof (struct shared_fd));
-		stdout_fd->sfd->type = STDOUT_FILENO;
-		list_push_back (&current->fd_table, &stdout_fd->file_elem);
+		if (stdout_fd->sfd == NULL) {
+			free (stdout_fd);
+		}
+		else {
+			stdout_fd->sfd->type = STDOUT_FILENO;
+			stdout_fd->sfd->shared_count = 1;
+			stdout_fd->sfd->file = NULL;
+			list_push_back (&current->fd_table, &stdout_fd->file_elem);
+		}
 	}
 }
 
@@ -315,6 +329,11 @@ __do_fork (void *aux) {
 		}
 		new_fde->fd = fde->fd;
 		new_fde->sfd = malloc (sizeof (struct shared_fd));
+		if (new_fde->sfd == NULL) {
+			free (new_fde);
+			thread_exit ();
+		}
+		new_fde->sfd->file = NULL;
 		if (is_file_fd (fde))
 			new_fde->sfd->file = file_duplicate (fde->sfd->file);
 		new_fde->sfd->shared_count = 1;
@@ -484,9 +503,10 @@ process_exit (void) {
 		struct fd_entry *entry = list_entry(e, struct fd_entry, file_elem);
 		list_remove(e);
 		entry->sfd->shared_count--;
-		if (is_file_fd (entry) && entry->sfd->shared_count == 0)
+		if (entry->sfd->shared_count == 0)
 		{
-			file_close (entry->sfd->file);
+			if (is_file_fd (entry))
+				file_close (entry->sfd->file);
 			free (entry->sfd);
 		}
 		free(entry);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -343,8 +343,10 @@ process_exec (void *f_name) {
 
 	/* And then load the binary */
 	success = load (arg, &_if);
+	
 	if (success)
 	{
+		
 		while(arg != NULL && arg_count < 32)
 		{
 			argv_tokens[arg_count++] = arg;
@@ -459,7 +461,7 @@ process_exit (void) {
 		file_close (entry->file);
 		free(entry);
 	}
-
+#ifdef USERPROG
 	struct child_status *cs = curr->wait_status;
 
 	if (cs != NULL) {
@@ -469,6 +471,8 @@ process_exit (void) {
 		cs->exited = true;
 		sema_up (&cs->wait_sema);
 	}
+
+#endif
 	process_cleanup ();
 }
 
@@ -669,8 +673,13 @@ load (const char *file_name, struct intr_frame *if_) {
 
 	/* TODO: Your code goes here.
 	 * TODO: Implement argument passing (see project2/argument_passing.html). */
-
 	success = true;
+#ifdef USERPROG
+	t->running_file = file;
+	file_deny_write(file);
+	return success;
+#endif
+	
 
 done:
 	/* We arrive here whether the load is successful or not. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -293,7 +293,9 @@ __do_fork (void *aux) {
 			thread_exit ();
 		}
 		new_fde->fd = fde->fd;
-		new_fde->file = file_duplicate (fde->file);
+		new_fde->sfd = malloc (sizeof (struct shared_fd));
+		new_fde->sfd->file = file_duplicate (fde->sfd->file);
+		new_fde->sfd->shared_count = 1;
 		list_push_back (&current->fd_table, &new_fde->file_elem);
 	}
 
@@ -458,13 +460,18 @@ process_exit (void) {
 		e = list_begin(fd_table);
 		struct fd_entry *entry = list_entry(e, struct fd_entry, file_elem);
 		list_remove(e);
-		file_close (entry->file);
+		entry->sfd->shared_count--;
+		if ( entry->sfd->shared_count == 0 )
+		{
+			file_close (entry->sfd->file);
+			free (entry->sfd);
+		}
 		free(entry);
 	}
 #ifdef USERPROG
-	if ( curr->running_file != NULL ){
+	if ( curr->running_file != NULL ){	
 		file_allow_write(curr->running_file);
-		file_close(curr->running_file);
+		file_close(curr->running_file);	
 		curr->running_file = NULL;
 	}
 	struct child_status *cs = curr->wait_status;
@@ -476,6 +483,9 @@ process_exit (void) {
 		cs->exited = true;
 		sema_up (&cs->wait_sema);
 	}
+
+
+
 
 #endif
 	process_cleanup ();

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -462,6 +462,11 @@ process_exit (void) {
 		free(entry);
 	}
 #ifdef USERPROG
+	if ( curr->running_file != NULL ){
+		file_allow_write(curr->running_file);
+		file_close(curr->running_file);
+		curr->running_file = NULL;
+	}
 	struct child_status *cs = curr->wait_status;
 
 	if (cs != NULL) {
@@ -677,11 +682,10 @@ load (const char *file_name, struct intr_frame *if_) {
 #ifdef USERPROG
 	t->running_file = file;
 	file_deny_write(file);
-	return success;
+	file = NULL;	
 #endif
-	
-
 done:
+
 	/* We arrive here whether the load is successful or not. */
 	file_close (file);
 	return success;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -42,6 +42,8 @@ static void sys_exit (int status);
 #define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target */
 #define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags */
 
+#define FILE_TYPE 3
+
 void
 syscall_init (void) {
 	write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48  |
@@ -212,7 +214,10 @@ syscall_handler (struct intr_frame *f) {
 			}
 
 			entry->fd = max_fd + 1;
-			entry->file = file;
+			entry->sfd = malloc (sizeof (struct shared_fd));
+			entry->sfd->type = FILE_TYPE;
+			entry->sfd->file = file;
+			entry->sfd->shared_count = 1;
 			list_push_back (&cur->fd_table, &entry->file_elem);
 			f->R.rax = entry->fd;
 			break;
@@ -225,7 +230,7 @@ syscall_handler (struct intr_frame *f) {
 				f->R.rax = -1;
 				break;
 			}
-			f->R.rax = file_length(entry->file);
+			f->R.rax = file_length(entry->sfd->file);
 			break;
 		}
 		case SYS_READ:
@@ -259,7 +264,7 @@ syscall_handler (struct intr_frame *f) {
 				break;
 			}
 
-			f->R.rax = file_read (fd_entry->file, buf, size);
+			f->R.rax = file_read (fd_entry->sfd->file, buf, size);
 			break;
 		}
 		case SYS_WRITE:
@@ -281,7 +286,7 @@ syscall_handler (struct intr_frame *f) {
 				f->R.rax = -1;
 				break;
 			}
-			f->R.rax = file_write(entry->file, buf, size);
+			f->R.rax = file_write(entry->sfd->file, buf, size);
 			break;
 		}
 		case SYS_SEEK:
@@ -295,7 +300,7 @@ syscall_handler (struct intr_frame *f) {
 			if (fd_entry == NULL) {
 				break;
 			}
-			file_seek (fd_entry->file, pos);
+			file_seek (fd_entry->sfd->file, pos);
 			break;
 		}
 		case SYS_TELL:
@@ -306,7 +311,7 @@ syscall_handler (struct intr_frame *f) {
 				f->R.rax = -1;
 				break;
 			}
-			f->R.rax = file_tell (fd_entry->file);
+			f->R.rax = file_tell (fd_entry->sfd->file);
 			break;
 		}
 		case SYS_CLOSE:
@@ -319,7 +324,11 @@ syscall_handler (struct intr_frame *f) {
 			}
 
 			list_remove (&fd_entry->file_elem);
-			file_close (fd_entry->file);
+			fd_entry->sfd->shared_count--;
+			if (fd_entry->sfd->shared_count == 0)
+			{
+				file_close (fd_entry->sfd->file);
+			}
 			free (fd_entry);
 			break;
 		}
@@ -327,7 +336,46 @@ syscall_handler (struct intr_frame *f) {
 		{
 			int fd_1 = f->R.rdi;
 			int fd_2 = f->R.rsi;
+			struct fd_entry *fd_entry_1 = find_fd_entry (fd_1);
+			if (fd_entry_1 == NULL) {
+				f->R.rax = -1;
+				break;
+			}
+			struct fd_entry *fd_entry_2 = find_fd_entry (fd_2);
+			if ( fd_entry_2 != NULL && fd_entry_1->sfd == fd_entry_2->sfd )
+			{
+				f->R.rax = fd_entry_2->fd;
+				break;
+			}
+			if (fd_entry_2 == NULL) 
+			{
+				struct fd_entry *entry = malloc (sizeof *entry);
+				struct thread *cur = thread_current();
+				if (entry == NULL) {
+					f->R.rax = -1;
+					break;
+				}
+				entry->sfd = malloc ( sizeof (struct shared_fd));
+				entry->fd = fd_2;
+				entry->sfd = fd_entry_1->sfd;
+				entry->sfd->shared_count++;
+				list_push_back (&cur->fd_table, &entry->file_elem);
+				f->R.rax = entry->fd;	
+
+			}
+			else
+			{
+				fd_entry_2->sfd->shared_count--;
+				if (fd_entry_2->sfd->shared_count == 0)
+				{
+					file_close (fd_entry_2->sfd->file);
+				}
+				fd_entry_2->sfd = fd_entry_1->sfd;
+				fd_entry_2->sfd->shared_count++;
+				f->R.rax = fd_entry_2->fd;
+			}
 			
+			break;
 
 		}
 		default:

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -332,16 +332,15 @@ syscall_handler (struct intr_frame *f) {
 				f->R.rax = -1;
 				break;
 			}
-			if (fd_entry->sfd->type == FILE_TYPE)
+			list_remove (&fd_entry->file_elem);
+			fd_entry->sfd->shared_count--;
+			if (fd_entry->sfd->shared_count == 0)
 			{
-				list_remove (&fd_entry->file_elem);
-				fd_entry->sfd->shared_count--;
-				if (fd_entry->sfd->shared_count == 0)
-				{
+				if (fd_entry->sfd->type == FILE_TYPE)
 					file_close (fd_entry->sfd->file);
-				}
-				free (fd_entry);
+				free (fd_entry->sfd);
 			}
+			free (fd_entry);
 			break;
 
 		}
@@ -368,7 +367,6 @@ syscall_handler (struct intr_frame *f) {
 					f->R.rax = -1;
 					break;
 				}
-				entry->sfd = malloc ( sizeof (struct shared_fd));
 				entry->fd = fd_2;
 				entry->sfd = fd_entry_1->sfd;
 				entry->sfd->shared_count++;
@@ -381,7 +379,9 @@ syscall_handler (struct intr_frame *f) {
 				fd_entry_2->sfd->shared_count--;
 				if (fd_entry_2->sfd->shared_count == 0)
 				{
-					file_close (fd_entry_2->sfd->file);
+					if (fd_entry_2->sfd->type == FILE_TYPE)
+						file_close (fd_entry_2->sfd->file);
+					free (fd_entry_2->sfd);
 				}
 				fd_entry_2->sfd = fd_entry_1->sfd;
 				fd_entry_2->sfd->shared_count++;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -42,8 +42,6 @@ static void sys_exit (int status);
 #define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target */
 #define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags */
 
-#define FILE_TYPE 3
-
 void
 syscall_init (void) {
 	write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48  |
@@ -179,7 +177,7 @@ syscall_handler (struct intr_frame *f) {
 			char *file_name = (char *) f->R.rdi;
 			if (!is_valid_string (file_name))
 				sys_exit (-1);
-			
+
 			f->R.rax = filesys_remove(file_name);
 			break;
 		}
@@ -226,10 +224,11 @@ syscall_handler (struct intr_frame *f) {
 		{
 			int fd = f->R.rdi;	
 			struct fd_entry *entry = find_fd_entry(fd);
-			if (entry == NULL) {
+			if (entry == NULL || entry->sfd->type != FILE_TYPE) {
 				f->R.rax = -1;
 				break;
 			}
+
 			f->R.rax = file_length(entry->sfd->file);
 			break;
 		}
@@ -246,20 +245,21 @@ syscall_handler (struct intr_frame *f) {
 				break;
 			}
 
-			if (fd == STDIN_FILENO) {
+
+			struct fd_entry *fd_entry = find_fd_entry (fd);
+			if (fd_entry == NULL) {
+				f->R.rax = -1;
+				break;
+			}
+
+			if (fd_entry->sfd->type == STDIN_FILENO) {
 				for (int i = 0; i < size; i++)
 					buf[i] = input_getc ();
 				f->R.rax = size;
 				break;
 			}
 
-			if (fd == STDOUT_FILENO) {
-				f->R.rax = -1;
-				break;
-			}
-
-			struct fd_entry *fd_entry = find_fd_entry (fd);
-			if (fd_entry == NULL) {
+			if (fd_entry->sfd->type == STDOUT_FILENO) {
 				f->R.rax = -1;
 				break;
 			}
@@ -275,18 +275,22 @@ syscall_handler (struct intr_frame *f) {
 			if (buf == NULL || !is_valid_buffer (buf, size))
 				sys_exit (-1);
 
-			if (fd == STDOUT_FILENO) {
-				putbuf (buf, size);
-				f->R.rax = size;
-				break;
-			}
+
 
 			struct fd_entry *entry = find_fd_entry (fd);
 			if (entry == NULL) {
 				f->R.rax = -1;
 				break;
 			}
-			f->R.rax = file_write(entry->sfd->file, buf, size);
+			if (entry->sfd->type == STDOUT_FILENO) {
+				putbuf (buf, size);
+				f->R.rax = size;
+				break;
+			}
+			if (entry->sfd->type == FILE_TYPE)
+			{
+				f->R.rax = file_write(entry->sfd->file, buf, size);
+			}
 			break;
 		}
 		case SYS_SEEK:
@@ -300,7 +304,10 @@ syscall_handler (struct intr_frame *f) {
 			if (fd_entry == NULL) {
 				break;
 			}
-			file_seek (fd_entry->sfd->file, pos);
+			if (fd_entry->sfd->type == FILE_TYPE)
+			{
+				file_seek (fd_entry->sfd->file, pos);
+			}
 			break;
 		}
 		case SYS_TELL:
@@ -311,7 +318,10 @@ syscall_handler (struct intr_frame *f) {
 				f->R.rax = -1;
 				break;
 			}
-			f->R.rax = file_tell (fd_entry->sfd->file);
+			if (fd_entry->sfd->type == FILE_TYPE)
+			{
+				f->R.rax = file_tell (fd_entry->sfd->file);
+			}
 			break;
 		}
 		case SYS_CLOSE:
@@ -322,15 +332,18 @@ syscall_handler (struct intr_frame *f) {
 				f->R.rax = -1;
 				break;
 			}
-
-			list_remove (&fd_entry->file_elem);
-			fd_entry->sfd->shared_count--;
-			if (fd_entry->sfd->shared_count == 0)
+			if (fd_entry->sfd->type == FILE_TYPE)
 			{
-				file_close (fd_entry->sfd->file);
+				list_remove (&fd_entry->file_elem);
+				fd_entry->sfd->shared_count--;
+				if (fd_entry->sfd->shared_count == 0)
+				{
+					file_close (fd_entry->sfd->file);
+				}
+				free (fd_entry);
 			}
-			free (fd_entry);
 			break;
+
 		}
 		case SYS_DUP2:
 		{

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -323,6 +323,13 @@ syscall_handler (struct intr_frame *f) {
 			free (fd_entry);
 			break;
 		}
+		case SYS_DUP2:
+		{
+			int fd_1 = f->R.rdi;
+			int fd_2 = f->R.rsi;
+			
+
+		}
 		default:
 			sys_exit (-1);
 			break;


### PR DESCRIPTION
## 변경 사항

- `dup2(oldfd, newfd)` syscall 기본 동작을 구현했습니다.
- 여러 fd가 같은 열린 file 상태를 공유할 수 있도록 `shared_fd` 구조를 추가했습니다.
- fd entry가 file/stdin/stdout 대상을 구분할 수 있도록 fd type을 관리했습니다.
- `dup2(fd, 1)`, `dup2(1, fd)` 케이스에서 stdout redirection이 동작하도록 처리했습니다.
- fd close 및 process exit 시 shared fd 참조 수를 기준으로 file close 시점을 관리했습니다.
- Project 2 extra 테스트인 dup2 테스트가 빌드/실행되도록 `Make.vars`의 extra 설정을 활성화했습니다.
- 코드 컨벤션에 맞춰 fd type 필드명, 지역 변수명, 함수 호출 공백, 매직 넘버 사용을 정리했습니다.

## 테스트 방법

1. `cd pintos/userprog`
2. `make`
3. `cd build`
4. `make tests/userprog/dup2/dup2-simple.result`
5. `make tests/userprog/dup2/dup2-complex.result`

## 테스트 결과

- [x] `tests/userprog/dup2/dup2-simple` PASS
- [x] `tests/userprog/dup2/dup2-complex` PASS

## 리뷰어가 확인할 것

- [ ] `dup2(oldfd, newfd)`에서 `oldfd` 유효성 검사가 올바른가?
- [ ] `newfd`가 이미 열려 있을 때 기존 fd 정리가 올바른가?
- [ ] dup된 fd끼리 file offset을 공유하는가?
- [ ] fd close 시 마지막 참조에서만 file이 닫히는가?
- [ ] stdin/stdout fd가 dup 대상일 때 type 처리가 자연스러운가?
- [ ] process exit 시 fd table cleanup에서 중복 close나 leak 가능성이 없는가?
- [ ] 코드가 Pintos 스타일과 팀 코드 컨벤션을 따르는가?

## 관련 이슈

Closes #229 